### PR TITLE
Fix/30 circling parameters

### DIFF
--- a/html/Circling_Parameters.html
+++ b/html/Circling_Parameters.html
@@ -487,8 +487,8 @@
               <label
                 for="ph_a"
                 class="block text-xs font-medium text-gray-600 dark:text-gray-400"
-                data-i18n="circling.protectionAltitude"
-                >Prot. Altitude [ft AMSL]</label
+                data-i18n="circling.protectedHeight"
+                >Protected Height [ft AGL]</label
               >
               <input
                 id="ph_a"
@@ -524,8 +524,8 @@
               <label
                 for="ph_b"
                 class="block text-xs font-medium text-gray-600 dark:text-gray-400"
-                data-i18n="circling.protectionAltitude"
-                >Prot. Altitude [ft AMSL]</label
+                data-i18n="circling.protectedHeight"
+                >Protected Height [ft AGL]</label
               >
               <input
                 id="ph_b"
@@ -561,8 +561,8 @@
               <label
                 for="ph_c"
                 class="block text-xs font-medium text-gray-600 dark:text-gray-400"
-                data-i18n="circling.protectionAltitude"
-                >Prot. Altitude [ft AMSL]</label
+                data-i18n="circling.protectedHeight"
+                >Protected Height [ft AGL]</label
               >
               <input
                 id="ph_c"
@@ -598,8 +598,8 @@
               <label
                 for="ph_d"
                 class="block text-xs font-medium text-gray-600 dark:text-gray-400"
-                data-i18n="circling.protectionAltitude"
-                >Prot. Altitude [ft AMSL]</label
+                data-i18n="circling.protectedHeight"
+                >Protected Height [ft AGL]</label
               >
               <input
                 id="ph_d"
@@ -635,8 +635,8 @@
               <label
                 for="ph_e"
                 class="block text-xs font-medium text-gray-600 dark:text-gray-400"
-                data-i18n="circling.protectionAltitude"
-                >Prot. Altitude [ft AMSL]</label
+                data-i18n="circling.protectedHeight"
+                >Protected Height [ft AGL]</label
               >
               <input
                 id="ph_e"
@@ -818,8 +818,8 @@
         return delta / theta; // sigma
       }
 
-      function calcCategory(ias_kt, protAlt_ft, bankDeg, deltaISA) {
-        const h1_ft = protAlt_ft; // Protection Altitude is AMSL — use directly
+      function calcCategory(ias_kt, protHeight_ft, elevFt, bankDeg, deltaISA) {
+        const h1_ft = elevFt + protHeight_ft; // h1 AMSL = aerodrome elevation + protected height AGL
         const sigma = calcDensityRatio(h1_ft, deltaISA);
         const k = 1 / Math.sqrt(sigma);
         const tas_kt = ias_kt * k;
@@ -840,12 +840,12 @@
       function buildResultsBody(elevFt, bankDeg, deltaISA) {
         // Default IAS values per ICAO PANS-OPS (kt)
         const DEFAULT_IAS = { A: 100, B: 135, C: 180, D: 205, E: 240 };
-        const defaultProtAlt = elevFt + 1000; // AMSL: aerodrome elev + 1000 ft
+        const DEFAULT_PROT_HEIGHT = 1000; // AGL height above aerodrome (ft)
 
         const rows = [
           { label: "IAS [KT]", id: "ias", dec: 0, isInput: true },
           {
-            label: "Protection Altitude [ft AMSL]",
+            label: "Protected Height [ft AGL]",
             id: "ph",
             dec: 0,
             isInput: true,
@@ -887,9 +887,9 @@
             return;
           }
           const iasModified = Math.abs(ias - DEFAULT_IAS[cat]) > 0.001;
-          const phModified = Math.abs(ph - defaultProtAlt) > 0.1;
+          const phModified = Math.abs(ph - DEFAULT_PROT_HEIGHT) > 0.1;
           if (iasModified || phModified) anyModified = true;
-          const res = calcCategory(ias, ph, bankDeg, deltaISA);
+          const res = calcCategory(ias, ph, elevFt, bankDeg, deltaISA);
           const S = S_CONST[cat];
           data[cat] = {
             ias: iasModified ? fmt(ias, 0) + " \u2020" : fmt(ias, 0),
@@ -954,7 +954,7 @@
       function rowI18nKey(id) {
         const map = {
           ias: "circling.ias",
-          ph: "circling.protectionAltitude",
+          ph: "circling.protectedHeight",
           h1: "circling.altitudeH1",
           k: "circling.kFactor",
           tasPlusWind: "circling.tasPlusWind",
@@ -1002,7 +1002,7 @@
           : unit === "m"
             ? elevRaw / ft2m
             : elevRaw;
-        const defProtAlt = Math.round(elevFt + 1000);
+        const defProtHeight = 1000; // AGL — constant regardless of aerodrome elevation
 
         ["a", "b", "c", "d", "e"].forEach((c) => {
           const iasEl = document.getElementById(`ias_${c}`);
@@ -1015,17 +1015,12 @@
             iasEl.classList.add("input-is-default");
           }
 
-          // Protection altitude: update when elevation changes
-          const prevPhDefault = parseFloat(phEl.dataset.default);
-          if (
-            !phEl.dataset.default ||
-            isNaN(prevPhDefault) ||
-            parseFloat(phEl.value) === prevPhDefault
-          ) {
-            phEl.value = defProtAlt;
+          // Protected height default: 1000 ft AGL (constant)
+          if (!phEl.dataset.default) {
+            phEl.value = defProtHeight;
+            phEl.dataset.default = defProtHeight;
             phEl.classList.add("input-is-default");
           }
-          phEl.dataset.default = defProtAlt;
         });
       }
 
@@ -1113,8 +1108,6 @@
       // Auto-calculate on global input change
       ["aerodromeElev", "elevUnit", "bankAngle", "deltaISA"].forEach((id) => {
         document.getElementById(id).addEventListener("change", () => {
-          // Re-apply protection altitude default when elevation changes
-          if (id === "aerodromeElev" || id === "elevUnit") applyDefaults();
           if (
             !document.getElementById("results").classList.contains("hidden")
           ) {

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -250,7 +250,7 @@
     "perCategoryInputs": "Per-Category Parameters",
     "parameters": "Parameters",
     "ias": "IAS [KT]",
-    "protectedHeight": "Protected Height [ft]",
+    "protectedHeight": "Protected Height [ft AGL]",
     "protectionAltitude": "Protection Altitude [ft AMSL]",
     "altitudeH1": "Altitude (h1) [ft]",
     "kFactor": "K Factor",

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -250,7 +250,7 @@
     "perCategoryInputs": "Par\u00e1metros por Categor\u00eda",
     "parameters": "Par\u00e1metros",
     "ias": "IAS [KT]",
-    "protectedHeight": "Altura Protegida [ft]",
+    "protectedHeight": "Altura Protegida [ft AGL]",
     "protectionAltitude": "Altitud de Protección [ft AMSL]",
     "altitudeH1": "Altitud (h1) [ft]",
     "kFactor": "Factor K",


### PR DESCRIPTION
# fix(#30): Circling Parameters  full implementation & corrections
---

## Summary

Implements the Circling Parameters calculator based on the reference Excel
(`Circling_Excel.xlsx`), then applies follow-up corrections raised in the issue comments.

---

## Changes

### `html/Circling_Parameters.html`

- **Calculation accuracy**  All intermediate values use full floating-point precision. Rounding is
  applied only to displayed output (2 decimal places), matching the principle used throughout the app.

- **h1 formula corrected**  `h1 = aerodrome elevation (ft) + protected height (ft AGL)`.  
  An earlier iteration incorrectly treated the input as an AMSL altitude, causing the aerodrome
  elevation to be omitted from the result (e.g. elev = 116.8 ft, height = 1120 ft ? h1 should be
  **1236.8 ft**, not 1120 ft). Verified against the reference Excel.

- **Input label corrected**  field renamed to **"Protected Height [ft AGL]"**.  
  The value the user enters is a height above aerodrome (AGL), not an absolute AMSL altitude.

- **Default values pre-populated in red** on page load:
  - IAS per category: Cat A = 100 kt, B = 135 kt, C = 180 kt, D = 205 kt, E = 240 kt (ICAO defaults).
  - Protected Height default = **1000 ft AGL** (constant, independent of aerodrome elevation).
  - Inputs styled with red border/text (`input-is-default` CSS class); style reverts when the user
    edits the value and restores if the value is set back to the default.

- **Output table indicator**  non-default input values are flagged with a dagger () in the results
  table, with a footnote below explaining the symbol.

- **Formula panel removed**  the `<details>` block showing intermediate formulas was removed per
  issue feedback. Associated CSS also removed.

- **Results wrapper**  replaced the `bg-green-50` wrapper with the standard `mt-8 p-6 rounded-xl`
  pattern used in other tools.

- **Copy to Word fixed**  replaced `navigator.clipboard.writeText()` (plain text only) with the
  shared `copyToClipboard(tableHTML)` utility from `aviation-utils.js`, which writes HTML to the
  clipboard so Word preserves table formatting.

### `html/i18n/en.json` / `html/i18n/es.json`

- Added / updated `circling.protectedHeight` key:
  - EN: `"Protected Height [ft AGL]"`
  - ES: `"Altura Protegida [ft AGL]"`

---

## Testing checklist

- [ ] Values for all 5 CAT rows match the reference Excel for a given aerodrome elevation and ?ISA
- [ ] Default inputs display in red on load; turn black when modified
- [ ] Output table shows `` on rows where the protected height differs from 1000 ft AGL
- [ ] Formula panel is no longer visible
- [ ] "Copy to Word" pastes a formatted table into Microsoft Word
- [ ] Spanish translation renders correctly when language is switched to ES
