### PR TITLE
fix(#49): Centralise version string via shared-config.js

### DIFF
--- a/html/About.html
+++ b/html/About.html
@@ -6,6 +6,13 @@
     <title data-i18n="about.title">About — PANSOPS Calculator Suite</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="shared-config.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".app-version").forEach(function (el) {
+          el.textContent = "v" + (window.APP_VERSION || "?");
+        });
+      });
+    </script>
     <link rel="stylesheet" href="dark-mode.css" />
     <script src="i18n/i18n.js"></script>
     <style>
@@ -821,7 +828,7 @@
           >
             <div class="flex items-center gap-3 mb-2">
               <span
-                class="ver-badge px-2 py-0.5 rounded"
+                class="app-version ver-badge px-2 py-0.5 rounded"
                 style="
                   background: rgba(56, 189, 248, 0.12);
                   border: 1px solid rgba(56, 189, 248, 0.3);

--- a/html/Main.html
+++ b/html/Main.html
@@ -6,6 +6,13 @@
     <title data-i18n="common.suiteName">Aviation Calculators Suite</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="shared-config.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".app-version").forEach(function (el) {
+          el.textContent = "v" + (window.APP_VERSION || "?");
+        });
+      });
+    </script>
     <link rel="stylesheet" href="dark-mode.css" />
     <link
       rel="stylesheet"
@@ -1102,7 +1109,7 @@
               <span data-i18n="common.suiteName"
                 >Aviation Calculators Suite</span
               >
-              <span>v0.2.0</span>
+              <span class="app-version">v0.2.0</span>
             </div>
           </div>
         </div>
@@ -1389,7 +1396,7 @@
             </button>
 
             <span
-              class="text-gray-600"
+              class="app-version text-gray-600"
               style="
                 font-family: &quot;Share Tech Mono&quot;, monospace;
                 font-size: 0.72rem;

--- a/html/shared-config.js
+++ b/html/shared-config.js
@@ -55,3 +55,5 @@ tailwind.config = {
     },
   },
 };
+
+window.APP_VERSION = "0.3.0";


### PR DESCRIPTION
# fix(#49): Centralise version string via shared-config.js
---

## Summary

The suite version badge shown in `Main.html` (sidebar footer and topbar) was
hard-coded as `v0.2.0` while `About.html` already displayed `v0.3.0` in the
changelog timeline. This PR introduces a single source of truth —
`window.APP_VERSION` in `shared-config.js` — and injects it at runtime into
every element with the `app-version` CSS class.

---

## Changes

### `html/shared-config.js`

Appended at the end of the file:

```js
window.APP_VERSION = "0.3.0";
```

`shared-config.js` is already loaded by every page via
`<script src="shared-config.js"></script>` before `DOMContentLoaded`, so the
value is available synchronously to the injection script in every calculator
page.

---

### `html/Main.html`

#### Injection script (inserted after `shared-config.js` in `<head>`)

```html
<script>
  document.addEventListener("DOMContentLoaded", function () {
    document.querySelectorAll(".app-version").forEach(function (el) {
      el.textContent = "v" + (window.APP_VERSION || "?");
    });
  });
</script>
```

#### Sidebar footer version span

```diff
- <span>v0.2.0</span>
+ <span class="app-version">v0.2.0</span>
```

#### Topbar version badge (desktop)

```diff
- <span
-   class="text-gray-600"
+ <span
+   class="app-version text-gray-600"
    style="font-family: 'Share Tech Mono', monospace; font-size: 0.72rem;"
  >v0.2.0</span>
```

---

### `html/About.html`

#### Injection script (inserted after `shared-config.js` in `<head>`)

Same script block as `Main.html`.

#### Changelog v0.3.0 timeline badge

```diff
- <span class="ver-badge px-2 py-0.5 rounded" style="...">v0.3.0</span>
+ <span class="app-version ver-badge px-2 py-0.5 rounded" style="...">v0.3.0</span>
```

> **Note:** The older changelog entries (`v0.2.0`, `v0.1.0`) are intentionally
> left without the `app-version` class — they represent historical records and
> must always show their fixed version string.

---

## How to bump the version in future

1. Edit the single line in `html/shared-config.js`:
   ```js
   window.APP_VERSION = "0.4.0"; // change here only
   ```
2. The new version propagates automatically to every page that includes
   `shared-config.js`.

---

## Testing checklist

- [ ] Open `Main.html` → sidebar footer shows `v0.3.0`
- [ ] Open `Main.html` → topbar version badge (desktop) shows `v0.3.0`
- [ ] Open `About.html` → most-recent changelog badge shows `v0.3.0`
- [ ] `About.html` → older badges (`v0.2.0`, `v0.1.0`) still show their original values
- [ ] Dark mode: version badges render correctly in both light and dark themes
- [ ] Mobile: sidebar footer badge visible and correct on narrow viewport
