### PR TITLE
fix(#57): Fix TAS card alignment and sidebar label

### DIFF
--- a/html/Main.html
+++ b/html/Main.html
@@ -745,10 +745,10 @@
                     class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
                   >
                     <i
-                      class="fas fa-plane text-primary-400 text-xl w-5 h-5 mr-3 sidebar-icon flex-shrink-0"
+                      class="fas fa-plane text-primary-400 text-xl w-5 h-5 mr-3 sidebar-icon"
                     ></i>
-                    <span class="sidebar-label text-center leading-tight" data-i18n="tas.title"
-                      >True Airspeed (TAS) Calculator</span
+                    <span class="sidebar-label" data-i18n="tas.sidebarLabel"
+                      >True Airspeed Calculator</span
                     >
                   </button>
                 </li>

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -37,6 +37,7 @@
   },
   "tas": {
     "title": "True Airspeed (TAS) Calculator",
+    "sidebarLabel": "True Airspeed Calculator",
     "ias": "Indicated Airspeed (IAS)",
     "altitude": "Altitude",
     "isaDeviationVar": "ISA Deviation (VAR) in °C",

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -37,6 +37,7 @@
   },
   "tas": {
     "title": "Calculadora de Velocidad Verdadera (TAS)",
+    "sidebarLabel": "Calculadora Vel. Verdadera",
     "ias": "Velocidad Indicada (IAS)",
     "altitude": "Altitud",
     "isaDeviationVar": "Desviación ISA (VAR) en °C",


### PR DESCRIPTION
# fix(#57): Fix TAS card alignment and sidebar label

## Summary

Two visual issues on the TAS calculator entry:

1. **Card vertical alignment** — `TAS.html` body used `items-center`, floating
   the card in the middle of the viewport. All other tools snap to the top.
2. **Sidebar label wrapping** — The sidebar used the full page title
   "True Airspeed (TAS) Calculator" which wraps to two lines, breaking visual
   consistency with every other single-line sidebar entry.

---
<img width="251" height="410" alt="{9D7C5573-37F2-478D-87F0-F6AF89AC4C91}" src="https://github.com/user-attachments/assets/d9a9eb68-9721-490b-8a98-4885a22211b9" />

## Changes

### `html/TAS.html` — body vertical alignment

```diff
- class="bg-gray-50 dark:bg-gray-900 min-h-screen flex items-center justify-center p-4"
+ class="bg-gray-50 dark:bg-gray-900 min-h-screen flex items-start justify-center pt-8 p-4"
```

`justify-center` kept — card remains horizontally centred. `pt-8` adds top breathing room.

---

### `html/Main.html` — sidebar label

The label was too long for the sidebar width and wrapped to two lines. A shorter
sidebar-specific i18n key is used so the full title is preserved in the page header.

```diff
- <span class="sidebar-label" data-i18n="tas.title">True Airspeed (TAS) Calculator</span>
+ <span class="sidebar-label" data-i18n="tas.sidebarLabel">True Airspeed Calculator</span>
```

---

### `html/i18n/en.json` and `html/i18n/es.json` — new `tas.sidebarLabel` key

| File       | Key                | Value                       |
| ---------- | ------------------ | --------------------------- |
| `en.json`  | `tas.sidebarLabel` | `True Airspeed Calculator`  |
| `es.json`  | `tas.sidebarLabel` | `Calculadora Vel. Verdadera` |

`tas.title` is unchanged and still used in the TAS page header.

---

## Testing checklist

- [ ] **TAS.html** standalone — card snaps to top of viewport, not floating in the middle
- [ ] **TAS.html** inside Main.html — card aligns with top of content area
- [ ] **Sidebar (EN)** — TAS entry reads "True Airspeed Calculator" on a single line, visually aligned with ISA Deviation Calculator and Rate & Radius of Turn
- [ ] **Sidebar (ES)** — TAS entry reads "Calculadora Vel. Verdadera" on a single line
- [ ] **TAS page header** — still shows full title "True Airspeed (TAS) Calculator"
- [ ] Dark mode — sidebar label colour and card background render correctly
