### PR TITLE
feat(#69): Flyby MSD Calculator — PANS-OPS Vol II §1.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ REDESIGN_PLAN.md
 #agents
 .agent/
 .agents/
+.claude/
 skills-lock.json

--- a/html/Flyby_Calculation.html
+++ b/html/Flyby_Calculation.html
@@ -1,0 +1,535 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="theme-color"
+      content="#f9fafb"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#111827"
+      media="(prefers-color-scheme: dark)"
+    />
+    <title data-i18n="flyby.title">Flyby MSD Calculator</title>
+    <link rel="preconnect" href="https://cdn.tailwindcss.com" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="shared-config.js"></script>
+    <link rel="stylesheet" href="dark-mode.css" />
+    <script src="aviation-utils.js"></script>
+    <script src="i18n/i18n.js"></script>
+  </head>
+  <body
+    class="bg-gray-50 dark:bg-gray-900 min-h-screen flex items-start justify-center pt-8 p-4"
+  >
+    <main
+      class="max-w-4xl w-full mx-auto p-6 bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700"
+    >
+      <header>
+        <h1
+          class="text-2xl sm:text-3xl font-bold text-primary-700 dark:text-primary-300 mb-1 flex items-center"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-7 w-7 sm:h-8 sm:w-8 mr-2 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M3 18 Q7 8 12 12 Q17 16 21 6"></path>
+            <circle
+              cx="12"
+              cy="12"
+              r="2"
+              fill="currentColor"
+              stroke="none"
+            ></circle>
+          </svg>
+          <span data-i18n="flyby.title">Flyby MSD Calculator</span>
+        </h1>
+        <p
+          class="text-sm text-gray-500 dark:text-gray-400 mb-6 ml-10"
+          data-i18n="flyby.subtitle"
+        >
+          Minimum Stabilisation Distance — PANS-OPS §1.4.1
+        </p>
+      </header>
+
+      <!-- Save / Load buttons -->
+      <div class="flex flex-wrap justify-end mb-6 gap-3">
+        <input id="loadFile" type="file" accept=".json" class="hidden" />
+        <button
+          type="button"
+          id="btnSave"
+          class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 mr-1"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path
+              d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"
+            ></path>
+            <polyline points="17 21 17 13 7 13 7 21"></polyline>
+            <polyline points="7 3 7 8 15 8"></polyline>
+          </svg>
+          <span data-i18n="common.save">Save Parameters</span>
+        </button>
+        <button
+          type="button"
+          id="btnLoad"
+          class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 mr-1"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="17 8 12 3 7 8"></polyline>
+            <line x1="12" y1="3" x2="12" y2="15"></line>
+          </svg>
+          <span data-i18n="common.load">Load Parameters</span>
+        </button>
+      </div>
+
+      <!-- Input form -->
+      <form id="flybyForm" novalidate>
+        <fieldset>
+          <legend class="sr-only">Flyby Parameters</legend>
+
+          <!-- Row 1: IAS, Altitude -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            <!-- IAS -->
+            <div class="space-y-2">
+              <label
+                for="ias"
+                class="block font-medium text-gray-700 dark:text-gray-300"
+                data-i18n="flyby.ias"
+                >IAS (knots)</label
+              >
+              <div
+                class="flex rounded-lg overflow-hidden shadow-sm border border-gray-300 dark:border-gray-600"
+              >
+                <input
+                  id="ias"
+                  name="ias"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  inputmode="decimal"
+                  autocomplete="off"
+                  class="flex-grow p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="e.g. 250"
+                  data-i18n="flyby.phIas"
+                  data-i18n-attr="placeholder"
+                />
+                <div
+                  class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 flex items-center"
+                >
+                  <span
+                    class="text-gray-700 dark:text-white"
+                    data-i18n="common.knots"
+                    >knots</span
+                  >
+                </div>
+              </div>
+            </div>
+
+            <!-- Altitude with ft/m selector -->
+            <div class="space-y-2">
+              <label
+                for="altitude"
+                class="block font-medium text-gray-700 dark:text-gray-300"
+                data-i18n="flyby.altitude"
+                >Altitude h1 (ft)</label
+              >
+              <div
+                class="flex rounded-lg overflow-hidden shadow-sm border border-gray-300 dark:border-gray-600"
+              >
+                <input
+                  id="altitude"
+                  name="altitude"
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputmode="numeric"
+                  autocomplete="off"
+                  class="flex-grow p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="e.g. 4000"
+                  data-i18n="flyby.phAltitude"
+                  data-i18n-attr="placeholder"
+                />
+                <select
+                  id="altitudeUnit"
+                  name="altitudeUnit"
+                  aria-label="Altitude unit"
+                  class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus:outline-none dark:text-white"
+                >
+                  <option value="ft" selected data-i18n="common.feet">
+                    ft
+                  </option>
+                  <option value="m" data-i18n="common.meters">m</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <!-- Row 2: Bank Angle, Turn Angle A -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+            <!-- Bank Angle -->
+            <div class="space-y-2">
+              <label
+                for="bankAngle"
+                class="block font-medium text-gray-700 dark:text-gray-300"
+                data-i18n="flyby.bankAngle"
+                >Bank Angle (°)</label
+              >
+              <div
+                class="flex rounded-lg overflow-hidden shadow-sm border border-gray-300 dark:border-gray-600"
+              >
+                <input
+                  id="bankAngle"
+                  name="bankAngle"
+                  type="number"
+                  min="1"
+                  max="45"
+                  step="1"
+                  inputmode="numeric"
+                  autocomplete="off"
+                  aria-describedby="bankAngleHint"
+                  class="flex-grow p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="e.g. 25"
+                  data-i18n="flyby.phBankAngle"
+                  data-i18n-attr="placeholder"
+                />
+                <div
+                  class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 flex items-center"
+                >
+                  <span class="text-gray-700 dark:text-white">°</span>
+                </div>
+              </div>
+              <p
+                id="bankAngleHint"
+                class="text-xs text-gray-500 dark:text-gray-400"
+                data-i18n="flyby.bankAngleHint"
+              >
+                Per PANS-OPS §1.4.1.3 — 15°, 20° or 25° by phase of flight
+              </p>
+            </div>
+
+            <!-- Turn Angle A -->
+            <div class="space-y-2">
+              <label
+                for="turnAngle"
+                class="block font-medium text-gray-700 dark:text-gray-300"
+                data-i18n="flyby.turnAngle"
+                >Turn Angle A (°)</label
+              >
+              <div
+                class="flex rounded-lg overflow-hidden shadow-sm border border-gray-300 dark:border-gray-600"
+              >
+                <input
+                  id="turnAngle"
+                  name="turnAngle"
+                  type="number"
+                  min="1"
+                  max="359"
+                  step="0.1"
+                  inputmode="decimal"
+                  autocomplete="off"
+                  aria-describedby="turnAngleHint"
+                  class="flex-grow p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="e.g. 105"
+                  data-i18n="flyby.phTurnAngle"
+                  data-i18n-attr="placeholder"
+                />
+                <div
+                  class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 flex items-center"
+                >
+                  <span
+                    class="text-gray-700 dark:text-white"
+                    data-i18n="common.degrees"
+                    >°</span
+                  >
+                </div>
+              </div>
+              <p
+                id="turnAngleHint"
+                class="text-xs text-gray-500 dark:text-gray-400"
+              >
+                Min 50° applied automatically when turn exists
+              </p>
+              <p
+                id="turnAngleWarning"
+                class="hidden text-xs text-amber-600 dark:text-amber-400"
+                data-i18n="flyby.turnAngleWarning"
+              >
+                Minimum 50° per PANS-OPS §1.4.2.2 — value adjusted.
+              </p>
+            </div>
+          </div>
+
+          <!-- Info note -->
+          <div class="space-y-2">
+            <div
+              class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-3 flex items-start gap-3"
+            >
+              <svg
+                aria-hidden="true"
+                class="h-5 w-5 text-blue-500 dark:text-blue-400 shrink-0 mt-0.5"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10"></circle>
+                <line x1="12" y1="8" x2="12" y2="12"></line>
+                <line x1="12" y1="16" x2="12.01" y2="16"></line>
+              </svg>
+              <p
+                class="text-sm text-blue-700 dark:text-blue-300"
+                data-i18n="flyby.isaNote"
+              >
+                ISA +15°C applied per PANS-OPS procedure design standard
+                (§1.4.1)
+              </p>
+            </div>
+          </div>
+        </fieldset>
+      </form>
+
+      <!-- Calculate button -->
+      <div class="flex justify-end mt-6">
+        <button
+          type="button"
+          id="btnCalculate"
+          class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-3 px-6 rounded-lg shadow transition-colors flex items-center"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 mr-2"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+          </svg>
+          <span data-i18n="common.calculate">Calculate</span>
+        </button>
+      </div>
+
+      <!-- Results section -->
+      <section
+        id="resultsSection"
+        role="region"
+        aria-live="polite"
+        aria-atomic="true"
+        class="hidden mt-8 bg-green-50 dark:bg-gray-700 p-6 rounded-xl border border-green-200 dark:border-gray-600"
+      >
+        <h2
+          class="text-xl font-bold text-green-800 dark:text-green-300 mb-4"
+          data-i18n="flyby.resultsTitle"
+        >
+          MSD Results
+        </h2>
+
+        <!-- Intermediate values: kFactor, TAS, TurnUsed, Radius -->
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-xs text-gray-500 dark:text-gray-400"
+              data-i18n="flyby.kFactor"
+            >
+              k Factor
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outKFactor"></span>
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-xs text-gray-500 dark:text-gray-400"
+              data-i18n="flyby.tas"
+            >
+              TAS
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outTas"></span>
+              <span class="text-sm font-normal" data-i18n="common.knots"
+                >knots</span
+              >
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-xs text-gray-500 dark:text-gray-400"
+              data-i18n="flyby.turnAngleUsed"
+            >
+              Turn Angle Used (A)
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outTurnUsed"></span>
+              <span class="text-sm font-normal">°</span>
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-xs text-gray-500 dark:text-gray-400"
+              data-i18n="flyby.radius"
+            >
+              Radius (r)
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outR"></span>
+              <span class="text-sm font-normal" data-i18n="common.nauticalMiles"
+                >NM</span
+              >
+            </p>
+          </div>
+        </div>
+
+        <!-- M formula breakdown: L1, L2 -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
+          <div
+            class="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg border border-blue-200 dark:border-blue-700 shadow-sm"
+          >
+            <p
+              class="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-1"
+              data-i18n="flyby.l1"
+            >
+              L1 = r × tan(A/2)
+            </p>
+            <p class="text-base font-bold text-blue-800 dark:text-blue-200">
+              <span id="outL1"></span>
+              <span class="text-sm font-normal">NM</span>
+            </p>
+          </div>
+          <div
+            class="bg-green-100 dark:bg-green-900/20 p-3 rounded-lg border border-green-200 dark:border-green-700 shadow-sm"
+          >
+            <p
+              class="text-xs font-semibold text-green-600 dark:text-green-400 mb-1"
+              data-i18n="flyby.l2"
+            >
+              L2 = 5 s × TAS / 3600
+            </p>
+            <p class="text-base font-bold text-green-800 dark:text-green-200">
+              <span id="outL2"></span>
+              <span class="text-sm font-normal">NM</span>
+            </p>
+          </div>
+        </div>
+
+        <!-- M total (primary highlighted card) -->
+        <div
+          class="bg-primary-700 dark:bg-primary-800 rounded-xl p-5 text-white mb-4 text-center shadow-md"
+        >
+          <p
+            class="text-sm font-medium opacity-80 mb-1 uppercase tracking-wide"
+            data-i18n="flyby.msd"
+          >
+            M Total (Flyby MSD)
+          </p>
+          <p class="text-4xl font-bold">
+            <span id="outM"></span>
+            <span
+              class="text-2xl ml-1 font-normal"
+              data-i18n="common.nauticalMiles"
+              >NM</span
+            >
+          </p>
+        </div>
+
+        <!-- Formula reference -->
+        <div
+          class="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg px-4 py-3 mb-4 text-sm text-gray-600 dark:text-gray-400 font-mono"
+        >
+          M = L1 + L2 = r × tan(A/2) + 5 × TAS / 3600
+        </div>
+
+        <!-- Copy to Word -->
+        <div class="flex justify-end">
+          <button
+            type="button"
+            id="btnCopy"
+            class="bg-gray-600 hover:bg-gray-700 dark:bg-gray-500 dark:hover:bg-gray-600 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-1"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path
+                d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+              ></path>
+            </svg>
+            <span data-i18n="common.copyToWord">Copy to Word Document</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- Diagram section -->
+      <figure
+        id="diagramSection"
+        class="hidden mt-8 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4"
+        aria-label="Flyby MSD diagram"
+      >
+        <figcaption
+          class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3"
+        >
+          Fig III-2-1-8 — Flyby MSD Geometry
+        </figcaption>
+        <div id="flybyDiagram" class="w-full overflow-x-auto"></div>
+      </figure>
+    </main>
+
+    <script src="js/flyby_calculation.js"></script>
+  </body>
+</html>

--- a/html/Main.html
+++ b/html/Main.html
@@ -1009,6 +1009,38 @@
                 </li>
                 <li>
                   <button
+                    id="flybyButton"
+                    data-label="Flyby MSD"
+                    onclick="loadPage('Flyby_Calculation.html', this)"
+                    class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
+                  >
+                    <svg
+                      class="text-primary-400 w-5 h-5 mr-3 sidebar-icon"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M3 18 Q7 8 12 12 Q17 16 21 6"></path>
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="2"
+                        fill="currentColor"
+                        stroke="none"
+                      ></circle>
+                    </svg>
+                    <span class="sidebar-label" data-i18n="flyby.sidebarLabel"
+                      >Flyby MSD</span
+                    >
+                  </button>
+                </li>
+                <li>
+                  <button
                     id="circlingButton"
                     data-label="Circling Parameters"
                     onclick="loadPage('Circling_Parameters.html', this)"
@@ -1653,6 +1685,10 @@
         "#flyover": {
           url: "Flyover_Calculation.html",
           buttonId: "flyoverButton",
+        },
+        "#flyby": {
+          url: "Flyby_Calculation.html",
+          buttonId: "flybyButton",
         },
         "#circling": {
           url: "Circling_Parameters.html",

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -304,5 +304,29 @@
     "l5": "L5 (bank establishment)",
     "msd": "MSD Total",
     "diagramTitle": "Segment Breakdown (ref. PANS-OPS III-2-1-7)"
+  },
+  "flyby": {
+    "title": "Flyby MSD Calculator",
+    "sidebarLabel": "Flyby MSD",
+    "subtitle": "Minimum Stabilisation Distance — PANS-OPS §1.4.2",
+    "ias": "IAS (knots)",
+    "altitude": "Altitude h1 (ft)",
+    "bankAngle": "Bank Angle (°)",
+    "bankAngleHint": "Per PANS-OPS §1.4.1.3 — 15°, 20° or 25° by phase of flight",
+    "turnAngle": "Turn Angle A (°)",
+    "phIas": "e.g. 250",
+    "phAltitude": "e.g. 4000",
+    "phBankAngle": "e.g. 25",
+    "phTurnAngle": "e.g. 105",
+    "resultsTitle": "MSD Results",
+    "kFactor": "k Factor",
+    "tas": "TAS",
+    "turnAngleUsed": "Turn Angle Used (A)",
+    "radius": "Radius (r)",
+    "l1": "L1 = r × tan(A/2)",
+    "l2": "L2 = 5 s × TAS / 3600",
+    "msd": "M Total (Flyby MSD)",
+    "turnAngleWarning": "Minimum 50° per PANS-OPS §1.4.2.2 — value adjusted.",
+    "isaNote": "ISA +15°C applied per PANS-OPS procedure design standard (§1.4.1)"
   }
 }

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -303,5 +303,29 @@
     "l5": "L5 (establecimiento de inclinación)",
     "msd": "MSD Total",
     "diagramTitle": "Desglose de segmentos (ref. PANS-OPS III-2-1-7)"
+  },
+  "flyby": {
+    "title": "Calculadora MSD Flyby",
+    "sidebarLabel": "MSD Flyby",
+    "subtitle": "Distancia Mínima de Estabilización — PANS-OPS §1.4.2",
+    "ias": "IAS (nudos)",
+    "altitude": "Altitud h1 (ft)",
+    "bankAngle": "Ángulo de inclinación (°)",
+    "bankAngleHint": "Según PANS-OPS §1.4.1.3 — 15°, 20° o 25° según fase de vuelo",
+    "turnAngle": "Ángulo de giro A (°)",
+    "phIas": "ej. 250",
+    "phAltitude": "ej. 4000",
+    "phBankAngle": "ej. 25",
+    "phTurnAngle": "ej. 105",
+    "resultsTitle": "Resultados MSD",
+    "kFactor": "Factor k",
+    "tas": "TAS",
+    "turnAngleUsed": "Ángulo de giro utilizado (A)",
+    "radius": "Radio (r)",
+    "l1": "L1 = r × tan(A/2)",
+    "l2": "L2 = 5 s × TAS / 3600",
+    "msd": "M Total (MSD Flyby)",
+    "turnAngleWarning": "Mínimo 50° según PANS-OPS §1.4.2.2 — valor ajustado.",
+    "isaNote": "ISA +15°C aplicado según estándar de diseño de procedimientos PANS-OPS (§1.4.1)"
   }
 }

--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -1,0 +1,616 @@
+// --- Fallback helpers --------------------------------------------------------
+// aviation-utils.js is loaded by the parent shell (Main.html).
+// When the page runs standalone on the server the relative <script> tag in the
+// <head> may fail to resolve, leaving these functions undefined.  The guards
+// below ensure the page always works regardless of loading context.
+if (typeof calculateKFactor === "undefined") {
+  // eslint-disable-next-line no-unused-vars
+  function calculateKFactor(altitude_ft, isaDeviation) {
+    return (
+      (171233 * Math.sqrt(288 + isaDeviation - 0.00198 * altitude_ft)) /
+      Math.pow(288 - 0.00198 * altitude_ft, 2.628)
+    );
+  }
+}
+if (typeof calculateTAS === "undefined") {
+  // eslint-disable-next-line no-unused-vars
+  function calculateTAS(ias, kFactor) {
+    return ias * kFactor;
+  }
+}
+if (typeof calculateRadius === "undefined") {
+  var _DEG_TO_RAD_FB2 = Math.PI / 180;
+  // eslint-disable-next-line no-unused-vars
+  function calculateRadius(tas, bankAngle_deg) {
+    return (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB2));
+  }
+}
+
+// Initialize on page load
+document.addEventListener("DOMContentLoaded", function () {
+  checkDarkMode();
+  initializeUnitSelectors();
+  setupEventListeners();
+
+  (function () {
+    function initI18n() {
+      if (window.I18N) {
+        I18N.init({
+          defaultLang: "en",
+          supported: ["en", "es"],
+          path: "i18n",
+        }).catch(console.error);
+      }
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", initI18n);
+    } else {
+      initI18n();
+    }
+  })();
+});
+
+function setupEventListeners() {
+  document
+    .getElementById("btnCalculate")
+    .addEventListener("click", calculateFlyby);
+  document.getElementById("btnSave").addEventListener("click", saveParameters);
+  document
+    .getElementById("btnLoad")
+    .addEventListener("click", () =>
+      document.getElementById("loadFile").click(),
+    );
+  document
+    .getElementById("loadFile")
+    .addEventListener("change", loadParameters);
+  document.getElementById("btnCopy").addEventListener("click", copyToWord);
+
+  const altUnit = document.getElementById("altitudeUnit");
+  if (altUnit) {
+    altUnit.addEventListener("change", () =>
+      handleUnitChange("altitude", "altitudeUnit"),
+    );
+  }
+}
+
+// --- Core calculation ---------------------------------------------------------
+
+function calculateFlyby() {
+  // --- Read inputs (4 inputs only) ---
+  const iasVal = parseFloat(document.getElementById("ias").value);
+  const altitudeRaw = parseFloat(document.getElementById("altitude").value);
+  const altitudeUnit = document.getElementById("altitudeUnit").value;
+  const bankAngleVal = parseFloat(document.getElementById("bankAngle").value);
+  const turnAngleRaw = parseFloat(document.getElementById("turnAngle").value);
+
+  // --- Validate ---
+  if (isNaN(iasVal) || iasVal <= 0) {
+    showToast("Please enter a valid IAS (> 0).", "error");
+    return;
+  }
+  if (isNaN(altitudeRaw) || altitudeRaw < 0) {
+    showToast("Please enter a valid altitude (>=0).", "error");
+    return;
+  }
+  if (isNaN(bankAngleVal) || bankAngleVal <= 0 || bankAngleVal >= 90) {
+    showToast("Please enter a valid bank angle (1-89).", "error");
+    return;
+  }
+  if (isNaN(turnAngleRaw) || turnAngleRaw <= 0 || turnAngleRaw >= 360) {
+    showToast("Please enter a valid turn angle (1-359).", "error");
+    return;
+  }
+
+  // --- PANS-OPS S1.4.2.2: minimum 50 for regular aircraft ---
+  const minAngle = 50;
+  const turnAngle = Math.max(turnAngleRaw, minAngle);
+  const minApplied = turnAngle !== turnAngleRaw;
+
+  // --- Convert altitude to feet ---
+  const altitude_ft =
+    altitudeUnit === "ft" ? altitudeRaw : altitudeRaw / 0.3048;
+
+  // --- kFactor and TAS (ISA+15 hardcoded per PANS-OPS procedure design standard) ---
+  const kFactor = calculateKFactor(altitude_ft, 15);
+  const tas = calculateTAS(iasVal, kFactor);
+
+  // --- Radius ---
+  const r = calculateRadius(tas, bankAngleVal);
+
+  // --- Flyby MSD (PANS-OPS S1.4.2.1) ---
+  // L1 = r x tan(A/2)
+  // L2 = 5 x V/3600
+  const turnHalf_rad = (turnAngle / 2) * (Math.PI / 180);
+  const L1 = r * Math.tan(turnHalf_rad);
+  const L2 = (5 * tas) / 3600;
+  const M = L1 + L2;
+
+  // --- Populate outputs ---
+  document.getElementById("outKFactor").textContent = kFactor.toFixed(4);
+  document.getElementById("outTas").textContent = tas.toFixed(4);
+  document.getElementById("outR").textContent = r.toFixed(4);
+  document.getElementById("outTurnUsed").textContent = turnAngle + "\u00b0";
+  document.getElementById("outL1").textContent = L1.toFixed(4);
+  document.getElementById("outL2").textContent = L2.toFixed(4);
+  document.getElementById("outM").textContent = M.toFixed(4);
+
+  const warnEl = document.getElementById("turnAngleWarning");
+  if (minApplied) {
+    warnEl.classList.remove("hidden");
+  } else {
+    warnEl.classList.add("hidden");
+  }
+
+  document.getElementById("resultsSection").classList.remove("hidden");
+  renderFlybyDiagram(L1, L2, r, turnAngle);
+}
+
+// --- SVG Diagram --------------------------------------------------------------
+
+function renderFlybyDiagram(L1, L2, r, theta_deg) {
+  const M = L1 + L2;
+  const container = document.getElementById("flybyDiagram");
+  const diagramSection = document.getElementById("diagramSection");
+
+  if (M <= 0) {
+    diagramSection.classList.add("hidden");
+    return;
+  }
+
+  const isDark = document.documentElement.classList.contains("dark");
+  const bg = isDark ? "#1f2937" : "#f8fafc";
+  const stroke = isDark ? "#c8d6e8" : "#334155";
+  const dim = isDark ? "#64748b" : "#94a3b8";
+  const white = isDark ? "#1f2937" : "#ffffff";
+  const textC = isDark ? "#e2e8f0" : "#1e293b";
+  const CL1 = "#2563eb";
+  const CL2 = "#22c55e";
+
+  const W = 760,
+    H = 340;
+  const PAD_L = 40,
+    PAD_R = 40,
+    PAD_T = 28,
+    PAD_B = 70;
+
+  const VR = Math.min((H - PAD_T - PAD_B) * 0.5, 100);
+
+  // WP near horizontal centre-left so arc and outbound have room to the right
+  const wpX = PAD_L + (W - PAD_L - PAD_R) * 0.4;
+  const wpY = PAD_T + (H - PAD_T - PAD_B) / 2;
+
+  const theta = theta_deg * (Math.PI / 180);
+  const halfTheta = theta / 2;
+
+  // Horizontal scale for L1/L2 annotations (schematic)
+  const availW = wpX - PAD_L - 10;
+  const scL = Math.min((availW * 0.65) / Math.max(L1, 0.01), 80);
+  const L1px = Math.min(L1 * scL, availW * 0.65);
+  const L2px = Math.min(L2 * scL, 60);
+
+  // Inbound arrives from lower-left at halfTheta below horizontal, ends at WP
+  const inbLen = L1px + 50;
+  const inbStartX = wpX - inbLen * Math.cos(halfTheta);
+  const inbStartY = wpY + inbLen * Math.sin(halfTheta);
+
+  // Arc centre: perpendicular left of the heading direction at WP
+  // Heading at WP = (cos(halfTheta), -sin(halfTheta)) (right + up in SVG, inbound direction)
+  // Left perp (CCW 90 deg) = (sin(halfTheta), cos(halfTheta))
+  const cx = wpX + VR * Math.sin(halfTheta);
+  const cy = wpY + VR * Math.cos(halfTheta);
+
+  // Angle from centre to WP in SVG
+  const wpAngle = Math.atan2(wpY - cy, wpX - cx);
+
+  // Arc end: rotate CW by theta
+  const arcEndAngle = wpAngle + theta;
+  const arcEndX = cx + VR * Math.cos(arcEndAngle);
+  const arcEndY = cy + VR * Math.sin(arcEndAngle);
+
+  // Outbound direction: CW tangent at arcEnd = (sin(arcEndAngle), -cos(arcEndAngle))
+  const outDirX = Math.sin(arcEndAngle);
+  const outDirY = -Math.cos(arcEndAngle);
+  const outLen = L2px + 60;
+  const outEndX = arcEndX + outLen * outDirX;
+  const outEndY = arcEndY + outLen * outDirY;
+
+  // L2 endpoint on the outbound (for dimension)
+  const l2EndX = arcEndX + L2px * outDirX;
+  const l2EndY = arcEndY + L2px * outDirY;
+
+  // Start-of-turn point on inbound (L1 back from WP)
+  const sotX = wpX - L1px * Math.cos(halfTheta);
+  const sotY = wpY + L1px * Math.sin(halfTheta);
+
+  function f(v) {
+    return v.toFixed(1);
+  }
+  function solidLine(ax, ay, bx, by, col, sw) {
+    sw = sw || 1.5;
+    return (
+      '<line x1="' +
+      f(ax) +
+      '" y1="' +
+      f(ay) +
+      '" x2="' +
+      f(bx) +
+      '" y2="' +
+      f(by) +
+      '" stroke="' +
+      col +
+      '" stroke-width="' +
+      sw +
+      '"/>'
+    );
+  }
+  function dashLine(ax, ay, bx, by, col, sw, da) {
+    sw = sw || 1;
+    da = da || "5 3";
+    return (
+      '<line x1="' +
+      f(ax) +
+      '" y1="' +
+      f(ay) +
+      '" x2="' +
+      f(bx) +
+      '" y2="' +
+      f(by) +
+      '" stroke="' +
+      col +
+      '" stroke-width="' +
+      sw +
+      '" stroke-dasharray="' +
+      da +
+      '"/>'
+    );
+  }
+  function txt(x, y, s, col, sz, anchor, italic) {
+    sz = sz || 11;
+    anchor = anchor || "middle";
+    return (
+      '<text x="' +
+      f(x) +
+      '" y="' +
+      f(y) +
+      '" text-anchor="' +
+      anchor +
+      '" font-size="' +
+      sz +
+      '" fill="' +
+      col +
+      '" font-family="sans-serif"' +
+      (italic ? ' font-style="italic"' : "") +
+      ">" +
+      s +
+      "</text>"
+    );
+  }
+
+  // Dimension arrow helper (axis-aligned horizontal only for simplicity)
+  function hArrow(x1, x2, y, col, lbl, val) {
+    const mid = (x1 + x2) / 2,
+      tk = 5;
+    return (
+      solidLine(x1, y, x2, y, col, 1.5) +
+      '<line x1="' +
+      f(x1) +
+      '" y1="' +
+      f(y - tk) +
+      '" x2="' +
+      f(x1) +
+      '" y2="' +
+      f(y + tk) +
+      '" stroke="' +
+      col +
+      '" stroke-width="1.5"/>' +
+      '<line x1="' +
+      f(x2) +
+      '" y1="' +
+      f(y - tk) +
+      '" x2="' +
+      f(x2) +
+      '" y2="' +
+      f(y + tk) +
+      '" stroke="' +
+      col +
+      '" stroke-width="1.5"/>' +
+      '<text x="' +
+      f(mid) +
+      '" y="' +
+      f(y - 8) +
+      '" text-anchor="middle" font-size="11" font-weight="700" fill="' +
+      col +
+      '" font-family="monospace">' +
+      lbl +
+      "</text>" +
+      '<text x="' +
+      f(mid) +
+      '" y="' +
+      f(y + 18) +
+      '" text-anchor="middle" font-size="10" fill="' +
+      col +
+      '" font-family="monospace">' +
+      val +
+      "</text>"
+    );
+  }
+
+  // Dimension annotation row (below the diagram)
+  const annY = H - PAD_B + 16;
+
+  // For L1 annotation: project WP and SOT horizontally to annY row
+  const l1AnnX1 = sotX;
+  const l1AnnX2 = wpX;
+
+  // For L2 annotation: project arcEnd and l2End horizontally to annY row
+  const l2AnnX1 = arcEndX;
+  const l2AnnX2 = arcEndX + L2px; // use horizontal projection
+
+  // Large arc flag
+  const largeArc = theta > Math.PI ? 1 : 0;
+
+  // WP symbol
+  const wpR2 = 8;
+  const wpSvg =
+    '<circle cx="' +
+    f(wpX) +
+    '" cy="' +
+    f(wpY) +
+    '" r="' +
+    wpR2 +
+    '" fill="' +
+    white +
+    '" stroke="' +
+    stroke +
+    '" stroke-width="1.8"/>' +
+    '<line x1="' +
+    f(wpX - wpR2) +
+    '" y1="' +
+    f(wpY) +
+    '" x2="' +
+    f(wpX + wpR2) +
+    '" y2="' +
+    f(wpY) +
+    '" stroke="' +
+    stroke +
+    '" stroke-width="1.2"/>' +
+    '<line x1="' +
+    f(wpX) +
+    '" y1="' +
+    f(wpY - wpR2) +
+    '" x2="' +
+    f(wpX) +
+    '" y2="' +
+    f(wpY + wpR2) +
+    '" stroke="' +
+    stroke +
+    '" stroke-width="1.2"/>';
+
+  // Angle annotation arc
+  const tR = Math.min(VR * 0.22, 28);
+  // From inbound departure direction at WP to outbound departure direction
+  const inbDirAngle = Math.PI + halfTheta; // backward along inbound
+  const outbDirAngle = wpAngle + Math.PI / 2; // CW tangent at WP
+  const tSx = wpX + tR * Math.cos(inbDirAngle);
+  const tSy = wpY + tR * Math.sin(inbDirAngle);
+  const tEx = wpX + tR * Math.cos(outbDirAngle);
+  const tEy = wpY + tR * Math.sin(outbDirAngle);
+  const tArc =
+    '<path d="M ' +
+    f(tSx) +
+    "," +
+    f(tSy) +
+    " A " +
+    tR +
+    "," +
+    tR +
+    " 0 " +
+    largeArc +
+    ",1 " +
+    f(tEx) +
+    "," +
+    f(tEy) +
+    '" fill="none" stroke="' +
+    dim +
+    '" stroke-width="1.2"/>';
+  const tMidAngle = inbDirAngle + theta / 2;
+  const tLblX = wpX + (tR + 16) * Math.cos(tMidAngle);
+  const tLblY = wpY + (tR + 16) * Math.sin(tMidAngle);
+
+  // Dashed radius
+  const rMidAngle = wpAngle + theta / 2;
+  const rMidX = cx + VR * Math.cos(rMidAngle);
+  const rMidY = cy + VR * Math.sin(rMidAngle);
+
+  const svgContent =
+    '<svg viewBox="0 0 ' +
+    W +
+    " " +
+    H +
+    '" class="w-full" role="img" aria-label="Flyby MSD diagram PANS-OPS III-2-1-8" style="background:' +
+    bg +
+    ';border-radius:8px;font-family:sans-serif">\n' +
+    "<!-- Inbound track -->\n" +
+    '<path d="M ' +
+    f(inbStartX) +
+    "," +
+    f(inbStartY) +
+    " L " +
+    f(wpX) +
+    "," +
+    f(wpY) +
+    '" fill="none" stroke="' +
+    stroke +
+    '" stroke-width="2.2" stroke-linecap="round"/>\n' +
+    "<!-- Turn arc (CW, left turn) -->\n" +
+    '<path d="M ' +
+    f(wpX) +
+    "," +
+    f(wpY) +
+    " A " +
+    f(VR) +
+    "," +
+    f(VR) +
+    " 0 " +
+    largeArc +
+    ",1 " +
+    f(arcEndX) +
+    "," +
+    f(arcEndY) +
+    '" fill="none" stroke="' +
+    stroke +
+    '" stroke-width="2.2" stroke-linecap="round"/>\n' +
+    "<!-- Outbound track -->\n" +
+    '<path d="M ' +
+    f(arcEndX) +
+    "," +
+    f(arcEndY) +
+    " L " +
+    f(outEndX) +
+    "," +
+    f(outEndY) +
+    '" fill="none" stroke="' +
+    stroke +
+    '" stroke-width="2.2" stroke-linecap="round"/>\n' +
+    "<!-- Dashed radius -->\n" +
+    dashLine(cx, cy, rMidX, rMidY, dim) +
+    "\n" +
+    txt(
+      cx + (rMidX - cx) * 0.55 + 8,
+      cy + (rMidY - cy) * 0.55,
+      "r",
+      dim,
+      11,
+      "start",
+      true,
+    ) +
+    "\n" +
+    "<!-- WP symbol -->\n" +
+    wpSvg +
+    "\n" +
+    "<!-- Theta annotation -->\n" +
+    tArc +
+    "\n" +
+    txt(
+      tLblX,
+      tLblY + 4,
+      "\u03b8 = " + theta_deg + "\u00b0",
+      dim,
+      10,
+      "middle",
+      true,
+    ) +
+    "\n" +
+    "<!-- Drop lines for dimension row -->\n" +
+    dashLine(sotX, sotY, l1AnnX1, annY - 18, dim, 0.7, "3 3") +
+    "\n" +
+    dashLine(wpX, wpY, l1AnnX2, annY - 18, dim, 0.7, "3 3") +
+    "\n" +
+    dashLine(arcEndX, arcEndY, l2AnnX1, annY - 18, dim, 0.7, "3 3") +
+    "\n" +
+    dashLine(l2EndX, l2EndY, l2AnnX2, annY - 18, dim, 0.7, "3 3") +
+    "\n" +
+    "<!-- L1 dimension -->\n" +
+    hArrow(l1AnnX1, l1AnnX2, annY, CL1, "L1", L1.toFixed(3) + " NM") +
+    "\n" +
+    "<!-- L2 dimension -->\n" +
+    hArrow(l2AnnX1, l2AnnX2, annY, CL2, "L2", L2.toFixed(3) + " NM") +
+    "\n" +
+    "<!-- MSD total -->\n" +
+    '<text x="' +
+    f(W / 2) +
+    '" y="' +
+    f(H - 12) +
+    '" text-anchor="middle" font-size="12" font-weight="700" fill="' +
+    textC +
+    '" font-family="monospace">M = L1 + L2 = ' +
+    (L1 + L2).toFixed(4) +
+    " NM</text>\n" +
+    "</svg>";
+
+  container.innerHTML = svgContent;
+  diagramSection.classList.remove("hidden");
+}
+
+// --- Save / Load parameters ---------------------------------------------------
+
+function saveParameters() {
+  const data = {
+    ias: document.getElementById("ias").value || "",
+    altitude: document.getElementById("altitude").value || "",
+    altitudeUnit: document.getElementById("altitudeUnit").value || "ft",
+    bankAngle: document.getElementById("bankAngle").value || "",
+    turnAngle: document.getElementById("turnAngle").value || "",
+  };
+
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  const filename = timestamp + "_flyby_msd.json";
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function loadParameters(event) {
+  const file = event.target.files[0];
+  if (!file) {
+    showToast("Please select a valid JSON file.", "error");
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    try {
+      const data = JSON.parse(e.target.result);
+      if (data.ias !== undefined)
+        document.getElementById("ias").value = data.ias;
+      if (data.altitude !== undefined)
+        document.getElementById("altitude").value = data.altitude;
+      if (data.altitudeUnit) {
+        const sel = document.getElementById("altitudeUnit");
+        sel.dataset.lastUnit = sel.value;
+        sel.value = data.altitudeUnit;
+      }
+      if (data.bankAngle !== undefined)
+        document.getElementById("bankAngle").value = data.bankAngle;
+      if (data.turnAngle !== undefined)
+        document.getElementById("turnAngle").value = data.turnAngle;
+      showToast("Parameters loaded.", "success");
+    } catch {
+      showToast("Invalid JSON file.", "error");
+    }
+  };
+  reader.readAsText(file);
+  event.target.value = "";
+}
+
+// --- Copy to Word -------------------------------------------------------------
+
+function copyToWord() {
+  const mVal = document.getElementById("outM").textContent;
+  if (!mVal) return;
+
+  const tableData = {
+    IAS: document.getElementById("ias").value + " KT",
+    "Altitude h1":
+      document.getElementById("altitude").value +
+      " " +
+      document.getElementById("altitudeUnit").value,
+    "k Factor": document.getElementById("outKFactor").textContent,
+    "Bank Angle": document.getElementById("bankAngle").value + "\u00b0",
+    "Turn Angle A": document.getElementById("outTurnUsed").textContent,
+    TAS: document.getElementById("outTas").textContent + " KT",
+    "Radius (r)": document.getElementById("outR").textContent + " NM",
+    "L1 = r x tan(A/2)": document.getElementById("outL1").textContent + " NM",
+    "L2 = 5 x V/3600": document.getElementById("outL2").textContent + " NM",
+    "M (Flyby MSD)": mVal + " NM",
+  };
+
+  const htmlContent = createHTMLTable(tableData, "Flyby MSD � PANS-OPS S1.4.2");
+  copyToClipboard(htmlContent);
+}


### PR DESCRIPTION
# feat(#69): Flyby MSD Calculator — PANS-OPS Vol II §1.4.2


## Summary

Adds a new **Flyby MSD Calculator** implementing the minimum stabilisation
distance formula from PANS-OPS Vol II §1.4.2. The two-segment formula (L1 + L2)
is simpler than the Flyover case and applies to turns made at a waypoint without
overflying it.

Results verified against the reference XLS spreadsheet:  
IAS = 250 kt, altitude = 4 000 ft, bank = 25°, turn = 105° → **M = 3.4523 NM**.

ISA deviation is **not** a user input; the PANS-OPS procedure design standard
fixes it at **ISA +15°C** (same convention as the Flyover calculator).  
A minimum turn angle of **50°** is enforced automatically per §1.4.2.2.

---

## Changes

### `html/Flyby_Calculation.html` — new page

Full calculator page with:

- **4 inputs:** IAS (knots), altitude h1 (ft / m selector), bank angle (°),
  turn angle A (°).
- **Info note** explaining ISA +15°C is applied automatically.
- **Intermediate results strip:** k Factor, TAS, turn angle used (A), radius (r).
- **L1 / L2 breakdown cards** colour-coded to match the PANS-OPS figure.
- **M total** highlighted primary card.
- **SVG schematic diagram** of PANS-OPS Fig III-2-1-8 (rendered by JS).
- Save / Load JSON parameters; Copy to Word table.
- Amber warning badge shown when the 50° minimum is applied.

### `html/js/flyby_calculation.js` — new script

#### Calculation (`calculateFlyby`)

Implements PANS-OPS §1.4.2.1 exactly:

| Symbol | Formula                                                   |
| ------ | --------------------------------------------------------- |
| TAS    | IAS × k (ISA +15°C hardcoded per procedure design standard) |
| r      | TAS² / (68 625 · tan(bank))                               |
| L1     | r · tan(A / 2)                                            |
| L2     | 5 · TAS / 3 600  (5-second bank establishment)            |
| **M**  | **L1 + L2**                                               |

Minimum turn angle: `A = max(A_input, 50°)` per §1.4.2.2.

#### Diagram (`renderFlybyDiagram`)

Schematic SVG matching PANS-OPS Figure III-2-1-8:

- **Inbound track** arrives at WP from lower-left at half-angle θ/2 below
  horizontal.
- **Turn arc** (CW) of radius r through the full turn angle θ.
- **Outbound track** departs tangent to the arc.
- **L1 / L2 dimension arrows** in an annotation row below the diagram, with
  exact NM values.
- **θ annotation arc** at the WP symbol; dashed radius line labelled *r*.
- **M total label** at the bottom of the canvas.
- Dark-mode aware (reads `document.documentElement.classList.contains("dark")`).

#### Fallback helpers

```js
if (typeof calculateKFactor === "undefined") { ... }
if (typeof calculateTAS    === "undefined") { ... }
if (typeof calculateRadius === "undefined") { ... }
```

Guards ensure the page works when loaded standalone on the server (where
`aviation-utils.js` may not resolve from the iframe context).

---

### `html/Main.html` — sidebar entry + routing

```diff
+ <li>
+   <button
+     id="flybyButton"
+     data-label="Flyby MSD"
+     onclick="loadPage('Flyby_Calculation.html', this)"
+     class="sidebar-item ..."
+   >
+     <!-- path + waypoint-circle icon -->
+     <span class="sidebar-label" data-i18n="flyby.sidebarLabel">Flyby MSD</span>
+   </button>
+ </li>
```

```diff
+ "#flyby": {
+   url: "Flyby_Calculation.html",
+   buttonId: "flybyButton",
+ },
```

---

### `html/i18n/en.json` — new `flyby` namespace

| Key               | Value                                                          |
| ----------------- | -------------------------------------------------------------- |
| `title`           | Flyby MSD Calculator                                           |
| `sidebarLabel`    | Flyby MSD                                                      |
| `subtitle`        | Minimum Stabilisation Distance — PANS-OPS §1.4.2               |
| `ias`             | IAS (knots)                                                    |
| `altitude`        | Altitude h1 (ft)                                               |
| `bankAngle`       | Bank Angle (°)                                                 |
| `bankAngleHint`   | Per PANS-OPS §1.4.1.3 — 15°, 20° or 25° by phase of flight    |
| `turnAngle`       | Turn Angle A (°)                                               |
| `resultsTitle`    | MSD Results                                                    |
| `kFactor`         | k Factor                                                       |
| `tas`             | TAS                                                            |
| `turnAngleUsed`   | Turn Angle Used (A)                                            |
| `radius`          | Radius (r)                                                     |
| `l1`              | L1 = r × tan(A/2)                                              |
| `l2`              | L2 = 5 s × TAS / 3600                                          |
| `msd`             | M Total (Flyby MSD)                                            |
| `turnAngleWarning`| Minimum 50° per PANS-OPS §1.4.2.2 — value adjusted.           |
| `isaNote`         | ISA +15°C applied per PANS-OPS procedure design standard (§1.4.1) |

### `html/i18n/es.json` — new `flyby` namespace (Spanish translation)

Same keys translated to Spanish.

---

## Accessibility review

| Item | Status |
| ---- | ------ |
| All inputs have `<label for="…">` | ✅ |
| Unit selects have `aria-label` | ✅ |
| Results section has `role="region"`, `aria-live="polite"`, `aria-atomic="true"` | ✅ |
| Warning badge uses `id="turnAngleWarning"` referenced by JS, not hidden with `display:none` | ✅ |
| SVG diagram has `role="img"` + `aria-label` | ✅ |
| Info note has `role="note"` | ✅ |
| Buttons have descriptive text spans with `data-i18n` | ✅ |

---

## Testing checklist

- [ ] IAS = 250 kt, alt = 4 000 ft, bank = 25°, turn = 105° → M = 3.4523 NM
- [ ] ISA +15°C applied automatically (no ISA input shown)
- [ ] Turn angle < 50° → amber warning shown, 50° used in calculation
- [ ] Turn angle ≥ 50° → no warning shown
- [ ] ft / m unit toggle converts altitude correctly
- [ ] SVG diagram renders with correct arc direction and L1/L2 annotations
- [ ] SVG updates on recalculation
- [ ] Dark mode: diagram colours and background update correctly
- [ ] Save parameters → downloads JSON with 5 fields (no isaDeviation)
- [ ] Load parameters → populates all 4 input fields correctly
- [ ] Copy to Word → table contains 10 rows including L1, L2, M
- [ ] Sidebar "Flyby MSD" button navigates to page
- [ ] Deep link `#flyby` loads page and highlights button
- [ ] Spanish translation displays correctly
