### PR TITLE
Flyby Calculator — ISA Deviation Input, Corrected Diagram & Precision Toggle

### DIFF
--- a/html/Flyby_Calculation.html
+++ b/html/Flyby_Calculation.html
@@ -120,8 +120,8 @@
         <fieldset>
           <legend class="sr-only">Flyby Parameters</legend>
 
-          <!-- Row 1: IAS, Altitude -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          <!-- Row 1: IAS, Altitude, ISA Deviation -->
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
             <!-- IAS -->
             <div class="space-y-2">
               <label
@@ -194,6 +194,28 @@
                   <option value="m" data-i18n="common.meters">m</option>
                 </select>
               </div>
+            </div>
+
+            <!-- ISA Deviation -->
+            <div class="space-y-2">
+              <label
+                for="isaDeviation"
+                class="block font-medium text-gray-700 dark:text-gray-300"
+                data-i18n="flyby.isaDeviationVar"
+                >ISA Deviation (VAR) °C</label
+              >
+              <input
+                id="isaDeviation"
+                name="isaDeviation"
+                type="number"
+                step="0.1"
+                inputmode="decimal"
+                autocomplete="off"
+                class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 15"
+                data-i18n="flyby.phIsaDeviation"
+                data-i18n-attr="placeholder"
+              />
             </div>
           </div>
 
@@ -288,36 +310,6 @@
                 data-i18n="flyby.turnAngleWarning"
               >
                 Minimum 50° per PANS-OPS §1.4.2.2 — value adjusted.
-              </p>
-            </div>
-          </div>
-
-          <!-- Info note -->
-          <div class="space-y-2">
-            <div
-              class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-3 flex items-start gap-3"
-            >
-              <svg
-                aria-hidden="true"
-                class="h-5 w-5 text-blue-500 dark:text-blue-400 shrink-0 mt-0.5"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <circle cx="12" cy="12" r="10"></circle>
-                <line x1="12" y1="8" x2="12" y2="12"></line>
-                <line x1="12" y1="16" x2="12.01" y2="16"></line>
-              </svg>
-              <p
-                class="text-sm text-blue-700 dark:text-blue-300"
-                data-i18n="flyby.isaNote"
-              >
-                ISA +15°C applied per PANS-OPS procedure design standard
-                (§1.4.1)
               </p>
             </div>
           </div>
@@ -488,30 +480,34 @@
 
         <!-- Copy to Word -->
         <div class="flex justify-end">
-          <button
-            type="button"
-            id="btnCopy"
-            class="bg-gray-600 hover:bg-gray-700 dark:bg-gray-500 dark:hover:bg-gray-600 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-5 w-5 mr-1"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
+          <div class="inline-flex rounded-lg overflow-hidden shadow border border-gray-300 dark:border-gray-600 text-sm">
+            <!-- Precision selector -->
+            <label class="sr-only" for="copyPrecision">Precision</label>
+            <div class="relative flex items-center bg-gray-100 dark:bg-gray-700 border-r border-gray-300 dark:border-gray-600">
+              <select
+                id="copyPrecision"
+                class="appearance-none bg-transparent text-gray-700 dark:text-gray-200 font-medium pl-3 pr-8 py-2 focus:outline-none cursor-pointer"
+              >
+                <option value="rounded" data-i18n="common.copyRounded">Rounded (4 dec.)</option>
+                <option value="exact" data-i18n="common.copyExact">Exact</option>
+              </select>
+              <svg class="absolute right-2 h-3.5 w-3.5 text-gray-400 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+              </svg>
+            </div>
+            <!-- Copy button -->
+            <button
+              type="button"
+              id="btnCopy"
+              class="bg-gray-600 hover:bg-gray-700 dark:bg-gray-500 dark:hover:bg-gray-400 text-white font-medium py-2 px-4 flex items-center gap-1.5 transition-colors whitespace-nowrap"
             >
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-              <path
-                d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-              ></path>
-            </svg>
-            <span data-i18n="common.copyToWord">Copy to Word Document</span>
-          </button>
+              <svg aria-hidden="true" focusable="false" class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <span data-i18n="common.copyToWord">Copy to Word</span>
+            </button>
+          </div>
         </div>
       </section>
 

--- a/html/Flyby_Calculation.html
+++ b/html/Flyby_Calculation.html
@@ -480,19 +480,38 @@
 
         <!-- Copy to Word -->
         <div class="flex justify-end">
-          <div class="inline-flex rounded-lg overflow-hidden shadow border border-gray-300 dark:border-gray-600 text-sm">
+          <div
+            class="inline-flex rounded-lg overflow-hidden shadow border border-gray-300 dark:border-gray-600 text-sm"
+          >
             <!-- Precision selector -->
             <label class="sr-only" for="copyPrecision">Precision</label>
-            <div class="relative flex items-center bg-gray-100 dark:bg-gray-700 border-r border-gray-300 dark:border-gray-600">
+            <div
+              class="relative flex items-center bg-gray-100 dark:bg-gray-700 border-r border-gray-300 dark:border-gray-600"
+            >
               <select
                 id="copyPrecision"
                 class="appearance-none bg-transparent text-gray-700 dark:text-gray-200 font-medium pl-3 pr-8 py-2 focus:outline-none cursor-pointer"
               >
-                <option value="rounded" data-i18n="common.copyRounded">Rounded (4 dec.)</option>
-                <option value="exact" data-i18n="common.copyExact">Exact</option>
+                <option value="rounded" data-i18n="common.copyRounded">
+                  Rounded (4 dec.)
+                </option>
+                <option value="exact" data-i18n="common.copyExact">
+                  Exact
+                </option>
               </select>
-              <svg class="absolute right-2 h-3.5 w-3.5 text-gray-400 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+              <svg
+                class="absolute right-2 h-3.5 w-3.5 text-gray-400 pointer-events-none"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="2.5"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M19 9l-7 7-7-7"
+                />
               </svg>
             </div>
             <!-- Copy button -->
@@ -501,9 +520,21 @@
               id="btnCopy"
               class="bg-gray-600 hover:bg-gray-700 dark:bg-gray-500 dark:hover:bg-gray-400 text-white font-medium py-2 px-4 flex items-center gap-1.5 transition-colors whitespace-nowrap"
             >
-              <svg aria-hidden="true" focusable="false" class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                class="h-4 w-4 shrink-0"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                <path
+                  d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                ></path>
               </svg>
               <span data-i18n="common.copyToWord">Copy to Word</span>
             </button>

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -5,6 +5,8 @@
     "calculate": "Calculate",
     "copyTable": "Copy Results as Table",
     "copyToWord": "Copy to Word Document",
+    "copyRounded": "Rounded (4 dec.)",
+    "copyExact": "Exact (full precision)",
     "unit": "Unit",
     "language": "Language",
     "darkMode": "Dark Mode",
@@ -324,6 +326,8 @@
     "phAltitude": "e.g. 4000",
     "phBankAngle": "e.g. 25",
     "phTurnAngle": "e.g. 105",
+    "isaDeviationVar": "ISA Deviation (VAR) \u00b0C",
+    "phIsaDeviation": "e.g. 15",
     "resultsTitle": "MSD Results",
     "kFactor": "k Factor",
     "tas": "TAS",
@@ -333,6 +337,7 @@
     "l2": "L2 = 5 s × TAS / 3600",
     "msd": "M Total (Flyby MSD)",
     "turnAngleWarning": "Minimum 50° per PANS-OPS §1.4.2.2 — value adjusted.",
-    "isaNote": "ISA +15°C applied per PANS-OPS procedure design standard (§1.4.1)"
+    "isaDeviationVar": "ISA Deviation (VAR) °C",
+    "phIsaDeviation": "e.g. 15"
   }
 }

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -5,6 +5,8 @@
     "calculate": "Calcular",
     "copyTable": "Copiar resultados como tabla",
     "copyToWord": "Copiar al documento Word",
+    "copyRounded": "Redondeado (4 dec.)",
+    "copyExact": "Exacto (precisión completa)",
     "unit": "Unidad",
     "language": "Idioma",
     "darkMode": "Modo oscuro",
@@ -323,6 +325,8 @@
     "phAltitude": "ej. 4000",
     "phBankAngle": "ej. 25",
     "phTurnAngle": "ej. 105",
+    "isaDeviationVar": "Desviaci\u00f3n ISA (VAR) \u00b0C",
+    "phIsaDeviation": "ej. 15",
     "resultsTitle": "Resultados MSD",
     "kFactor": "Factor k",
     "tas": "TAS",
@@ -332,6 +336,7 @@
     "l2": "L2 = 5 s × TAS / 3600",
     "msd": "M Total (MSD Flyby)",
     "turnAngleWarning": "Mínimo 50° según PANS-OPS §1.4.2.2 — valor ajustado.",
-    "isaNote": "ISA +15°C aplicado según estándar de diseño de procedimientos PANS-OPS (§1.4.1)"
+    "isaDeviationVar": "Desviación ISA (VAR) °C",
+    "phIsaDeviation": "ej. 15"
   }
 }

--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -26,6 +26,22 @@ if (typeof calculateRadius === "undefined") {
   }
 }
 
+// Raw results store — populated after each calculation
+const _raw = {};
+
+// Update displayed result values based on the selected precision mode
+function applyDisplayPrecision() {
+  if (_raw.M === undefined) return;
+  const exact = document.getElementById("copyPrecision").value === "exact";
+  const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
+  document.getElementById("outKFactor").textContent = fmt(_raw.kFactor);
+  document.getElementById("outTas").textContent = fmt(_raw.tas);
+  document.getElementById("outR").textContent = fmt(_raw.r);
+  document.getElementById("outL1").textContent = fmt(_raw.L1);
+  document.getElementById("outL2").textContent = fmt(_raw.L2);
+  document.getElementById("outM").textContent = fmt(_raw.M);
+}
+
 // Initialize on page load
 document.addEventListener("DOMContentLoaded", function () {
   checkDarkMode();
@@ -64,6 +80,9 @@ function setupEventListeners() {
     .getElementById("loadFile")
     .addEventListener("change", loadParameters);
   document.getElementById("btnCopy").addEventListener("click", copyToWord);
+  document
+    .getElementById("copyPrecision")
+    .addEventListener("change", applyDisplayPrecision);
 
   const altUnit = document.getElementById("altitudeUnit");
   if (altUnit) {
@@ -76,12 +95,14 @@ function setupEventListeners() {
 // --- Core calculation ---------------------------------------------------------
 
 function calculateFlyby() {
-  // --- Read inputs (4 inputs only) ---
+  // --- Read inputs ---
   const iasVal = parseFloat(document.getElementById("ias").value);
   const altitudeRaw = parseFloat(document.getElementById("altitude").value);
   const altitudeUnit = document.getElementById("altitudeUnit").value;
   const bankAngleVal = parseFloat(document.getElementById("bankAngle").value);
   const turnAngleRaw = parseFloat(document.getElementById("turnAngle").value);
+  const isaDeviationRaw = document.getElementById("isaDeviation").value;
+  const isaDeviation = isaDeviationRaw === "" ? 0 : parseFloat(isaDeviationRaw);
 
   // --- Validate ---
   if (isNaN(iasVal) || iasVal <= 0) {
@@ -100,6 +121,10 @@ function calculateFlyby() {
     showToast("Please enter a valid turn angle (1-359).", "error");
     return;
   }
+  if (isNaN(isaDeviation)) {
+    showToast("Please enter a valid ISA deviation.", "error");
+    return;
+  }
 
   // --- PANS-OPS S1.4.2.2: minimum 50 for regular aircraft ---
   const minAngle = 50;
@@ -110,8 +135,8 @@ function calculateFlyby() {
   const altitude_ft =
     altitudeUnit === "ft" ? altitudeRaw : altitudeRaw / 0.3048;
 
-  // --- kFactor and TAS (ISA+15 hardcoded per PANS-OPS procedure design standard) ---
-  const kFactor = calculateKFactor(altitude_ft, 15);
+  // --- kFactor and TAS ---
+  const kFactor = calculateKFactor(altitude_ft, isaDeviation);
   const tas = calculateTAS(iasVal, kFactor);
 
   // --- Radius ---
@@ -125,14 +150,15 @@ function calculateFlyby() {
   const L2 = (5 * tas) / 3600;
   const M = L1 + L2;
 
-  // --- Populate outputs ---
-  document.getElementById("outKFactor").textContent = kFactor.toFixed(4);
-  document.getElementById("outTas").textContent = tas.toFixed(4);
-  document.getElementById("outR").textContent = r.toFixed(4);
+  // --- Store raw results and render with current precision ---
+  _raw.kFactor = kFactor;
+  _raw.tas = tas;
+  _raw.r = r;
+  _raw.L1 = L1;
+  _raw.L2 = L2;
+  _raw.M = M;
   document.getElementById("outTurnUsed").textContent = turnAngle + "\u00b0";
-  document.getElementById("outL1").textContent = L1.toFixed(4);
-  document.getElementById("outL2").textContent = L2.toFixed(4);
-  document.getElementById("outM").textContent = M.toFixed(4);
+  applyDisplayPrecision();
 
   const warnEl = document.getElementById("turnAngleWarning");
   if (minApplied) {
@@ -148,11 +174,10 @@ function calculateFlyby() {
 // --- SVG Diagram --------------------------------------------------------------
 
 function renderFlybyDiagram(L1, L2, r, theta_deg) {
-  const M = L1 + L2;
   const container = document.getElementById("flybyDiagram");
   const diagramSection = document.getElementById("diagramSection");
 
-  if (M <= 0) {
+  if (L1 + L2 <= 0) {
     diagramSection.classList.add("hidden");
     return;
   }
@@ -165,236 +190,230 @@ function renderFlybyDiagram(L1, L2, r, theta_deg) {
   const textC = isDark ? "#e2e8f0" : "#1e293b";
   const CL1 = "#2563eb";
   const CL2 = "#22c55e";
+  const CMSD = "#f97316";
+  const CNORTH = "#3b82f6";
 
-  const W = 760,
-    H = 340;
-  const PAD_L = 40,
-    PAD_R = 40,
-    PAD_T = 28,
-    PAD_B = 70;
-
-  const VR = Math.min((H - PAD_T - PAD_B) * 0.5, 100);
-
-  // WP near horizontal centre-left so arc and outbound have room to the right
-  const wpX = PAD_L + (W - PAD_L - PAD_R) * 0.4;
-  const wpY = PAD_T + (H - PAD_T - PAD_B) / 2;
+  const W = 860,
+    H = 460;
+  const PAD_L = 60,
+    PAD_R = 60,
+    PAD_T = 32,
+    PAD_B = 48;
+  const drawW = W - PAD_L - PAD_R;
+  const drawH = H - PAD_T - PAD_B;
 
   const theta = theta_deg * (Math.PI / 180);
-  const halfTheta = theta / 2;
 
-  // Horizontal scale for L1/L2 annotations (schematic)
-  const availW = wpX - PAD_L - 10;
-  const scL = Math.min((availW * 0.65) / Math.max(L1, 0.01), 80);
-  const L1px = Math.min(L1 * scL, availW * 0.65);
-  const L2px = Math.min(L2 * scL, 60);
+  // ── PANS-OPS Flyby geometry ───────────────────────────────────────────────
+  // WP = (0,0) = intersection of nominal inbound & outbound tracks.
+  // INBOUND = north = straight DOWN from WP (so the north arrow IS the inbound
+  // extension above WP, giving a clear θ arc from 0° to outbound).
+  // SVG: x→right, y→down.
+  //
+  // Inbound direction (toward WP, from below): (0, -1)
+  // Right-perpendicular (CW turn): (1, 0)  → arc center to the right of SOT
+  //
+  // SOT  = [0, L1]   (directly below WP by L1)
+  // cNM  = [r, L1]   (right of SOT by r)
+  // sotAng = π        (SOT is directly left of center)
+  // eotAng = π + θ
+  // oDX = sin(θ),  oDY = -cos(θ)   (outbound goes lower-right)
 
-  // Inbound arrives from lower-left at halfTheta below horizontal, ends at WP
-  const inbLen = L1px + 50;
-  const inbStartX = wpX - inbLen * Math.cos(halfTheta);
-  const inbStartY = wpY + inbLen * Math.sin(halfTheta);
+  const sotNM = [0, L1];
+  const cNM = [r, L1];
+  const sotAng = Math.PI;
+  const eotAng = Math.PI + theta;
+  const eotNM = [r + r * Math.cos(eotAng), L1 + r * Math.sin(eotAng)];
+  const oDX = Math.sin(theta); // = -sin(eotAng)
+  const oDY = -Math.cos(theta); // =  cos(eotAng)
 
-  // Arc centre: perpendicular left of the heading direction at WP
-  // Heading at WP = (cos(halfTheta), -sin(halfTheta)) (right + up in SVG, inbound direction)
-  // Left perp (CCW 90 deg) = (sin(halfTheta), cos(halfTheta))
-  const cx = wpX + VR * Math.sin(halfTheta);
-  const cy = wpY + VR * Math.cos(halfTheta);
+  const l2EndNM = [eotNM[0] + L2 * oDX, eotNM[1] + L2 * oDY];
 
-  // Angle from centre to WP in SVG
-  const wpAngle = Math.atan2(wpY - cy, wpX - cx);
+  const inbExt = Math.max(r * 0.28, L1 * 0.3);
+  const outExt = Math.max(r * 0.28, L2 * 0.3);
+  const inbStNM = [0, L1 + inbExt]; // below SOT (inbound goes straight down)
+  const outEndNM = [l2EndNM[0] + outExt * oDX, l2EndNM[1] + outExt * oDY];
 
-  // Arc end: rotate CW by theta
-  const arcEndAngle = wpAngle + theta;
-  const arcEndX = cx + VR * Math.cos(arcEndAngle);
-  const arcEndY = cy + VR * Math.sin(arcEndAngle);
+  // Arc midpoint for r label
+  const rMidAng = Math.PI + theta / 2;
+  const rMidNM = [r + r * Math.cos(rMidAng), L1 + r * Math.sin(rMidAng)];
 
-  // Outbound direction: CW tangent at arcEnd = (sin(arcEndAngle), -cos(arcEndAngle))
-  const outDirX = Math.sin(arcEndAngle);
-  const outDirY = -Math.cos(arcEndAngle);
-  const outLen = L2px + 60;
-  const outEndX = arcEndX + outLen * outDirX;
-  const outEndY = arcEndY + outLen * outDirY;
+  // ── Bounding box in NM ───────────────────────────────────────────────────
+  // WP (0,0) is the topmost, left-most point; all content is at x≥0, y≥0.
+  const allNMx = [0, eotNM[0], l2EndNM[0], outEndNM[0], rMidNM[0]];
+  const allNMy = [
+    inbStNM[1],
+    sotNM[1],
+    0,
+    eotNM[1],
+    l2EndNM[1],
+    outEndNM[1],
+    rMidNM[1],
+  ];
+  const minXnm = 0; // inbound is on x=0
+  const maxXnm = Math.max(...allNMx);
+  const maxYnm = Math.max(...allNMy);
 
-  // L2 endpoint on the outbound (for dimension)
-  const l2EndX = arcEndX + L2px * outDirX;
-  const l2EndY = arcEndY + L2px * outDirY;
+  // ── Scale & WP position ──────────────────────────────────────────────────
+  const northLen = 64;
+  const northLblMg = 18;
+  const topPad = northLen + northLblMg + 4;
 
-  // Start-of-turn point on inbound (L1 back from WP)
-  const sotX = wpX - L1px * Math.cos(halfTheta);
-  const sotY = wpY + L1px * Math.sin(halfTheta);
+  const contentH = drawH - topPad - 4;
+  const contentW = drawW;
+  const scH = contentH / Math.max(maxYnm, 0.01);
+  // reserve ~60px left of WP for the M dimension label offset
+  const dimLeftPad = 60;
+  const scW = (contentW - dimLeftPad) / Math.max(maxXnm + 0.1, 0.01);
+  const sc = Math.min(scH, scW) * 0.9;
 
+  // Center the full scene (dimLeftPad + scene width) in the draw area
+  const scenePxW = dimLeftPad + maxXnm * sc;
+  const wpX = PAD_L + dimLeftPad + Math.round((contentW - scenePxW) / 2);
+  const wpY = PAD_T + topPad;
+
+  // NM → SVG pixel
+  function px(nm) {
+    return [wpX + nm[0] * sc, wpY + nm[1] * sc];
+  }
+  const rPx = r * sc;
+
+  const [sotX, sotY] = px(sotNM);
+  const [inbStX, inbStY] = px(inbStNM);
+  const [cX, cY] = px(cNM);
+  const [eotX, eotY] = px(eotNM);
+  const [l2EndX, l2EndY] = px(l2EndNM);
+  const [outEndX, outEndY] = px(outEndNM);
+  const [rMidX, rMidY] = px(rMidNM);
+
+  const largeArc = theta > Math.PI ? 1 : 0;
+
+  // ── SVG helpers ───────────────────────────────────────────────────────────
   function f(v) {
     return v.toFixed(1);
   }
-  function solidLine(ax, ay, bx, by, col, sw) {
-    sw = sw || 1.5;
-    return (
+
+  function line(x1, y1, x2, y2, col, sw, dash) {
+    let s =
       '<line x1="' +
-      f(ax) +
+      f(x1) +
       '" y1="' +
-      f(ay) +
+      f(y1) +
       '" x2="' +
-      f(bx) +
+      f(x2) +
       '" y2="' +
-      f(by) +
+      f(y2) +
       '" stroke="' +
       col +
       '" stroke-width="' +
-      sw +
-      '"/>'
-    );
+      (sw || 1.5) +
+      '"';
+    if (dash) s += ' stroke-dasharray="' + dash + '"';
+    return s + "/>";
   }
-  function dashLine(ax, ay, bx, by, col, sw, da) {
-    sw = sw || 1;
-    da = da || "5 3";
-    return (
-      '<line x1="' +
-      f(ax) +
-      '" y1="' +
-      f(ay) +
-      '" x2="' +
-      f(bx) +
-      '" y2="' +
-      f(by) +
-      '" stroke="' +
-      col +
-      '" stroke-width="' +
-      sw +
-      '" stroke-dasharray="' +
-      da +
-      '"/>'
-    );
-  }
-  function txt(x, y, s, col, sz, anchor, italic) {
-    sz = sz || 11;
-    anchor = anchor || "middle";
+
+  function txt(x, y, s, col, sz, anchor, bold) {
     return (
       '<text x="' +
       f(x) +
       '" y="' +
       f(y) +
       '" text-anchor="' +
-      anchor +
+      (anchor || "middle") +
       '" font-size="' +
-      sz +
+      (sz || 11) +
       '" fill="' +
       col +
       '" font-family="sans-serif"' +
-      (italic ? ' font-style="italic"' : "") +
+      (bold ? ' font-weight="700"' : "") +
       ">" +
       s +
       "</text>"
     );
   }
 
-  // Dimension arrow helper (axis-aligned horizontal only for simplicity)
-  function hArrow(x1, x2, y, col, lbl, val) {
-    const mid = (x1 + x2) / 2,
-      tk = 5;
+  // Parallel-offset dimension line along a track segment
+  function dimLine(ax, ay, bx, by, col, lbl, val, od) {
+    od = od || 20;
+    const dx = bx - ax,
+      dy = by - ay,
+      len = Math.sqrt(dx * dx + dy * dy);
+    if (len < 2) return "";
+    const px2 = (-dy / len) * od,
+      py2 = (dx / len) * od; // left-perpendicular offset
+    const ax2 = ax + px2,
+      ay2 = ay + py2,
+      bx2 = bx + px2,
+      by2 = by + py2;
+    const mx = (ax2 + bx2) / 2,
+      my = (ay2 + by2) / 2;
+    const tk = 5,
+      nx = (-dy / len) * tk,
+      ny = (dx / len) * tk;
     return (
-      solidLine(x1, y, x2, y, col, 1.5) +
-      '<line x1="' +
-      f(x1) +
-      '" y1="' +
-      f(y - tk) +
-      '" x2="' +
-      f(x1) +
-      '" y2="' +
-      f(y + tk) +
-      '" stroke="' +
-      col +
-      '" stroke-width="1.5"/>' +
-      '<line x1="' +
-      f(x2) +
-      '" y1="' +
-      f(y - tk) +
-      '" x2="' +
-      f(x2) +
-      '" y2="' +
-      f(y + tk) +
-      '" stroke="' +
-      col +
-      '" stroke-width="1.5"/>' +
-      '<text x="' +
-      f(mid) +
-      '" y="' +
-      f(y - 8) +
-      '" text-anchor="middle" font-size="11" font-weight="700" fill="' +
-      col +
-      '" font-family="monospace">' +
-      lbl +
-      "</text>" +
-      '<text x="' +
-      f(mid) +
-      '" y="' +
-      f(y + 18) +
-      '" text-anchor="middle" font-size="10" fill="' +
-      col +
-      '" font-family="monospace">' +
-      val +
-      "</text>"
+      line(ax2, ay2, bx2, by2, col, 1.5) +
+      line(ax2 - nx, ay2 - ny, ax2 + nx, ay2 + ny, col, 1.5) +
+      line(bx2 - nx, by2 - ny, bx2 + nx, by2 + ny, col, 1.5) +
+      line(ax, ay, ax2, ay2, col, 0.6, "3 3") +
+      line(bx, by, bx2, by2, col, 0.6, "3 3") +
+      txt(mx, my - 7, lbl, col, 11, "middle", true) +
+      txt(mx, my + 14, val, col, 10, "middle", false)
     );
   }
 
-  // Dimension annotation row (below the diagram)
-  const annY = H - PAD_B + 16;
+  // Waypoint symbol (circle with crosshair)
+  function wpSym(x, y) {
+    const wr = 9;
+    return (
+      '<circle cx="' +
+      f(x) +
+      '" cy="' +
+      f(y) +
+      '" r="' +
+      wr +
+      '" fill="' +
+      white +
+      '" stroke="' +
+      stroke +
+      '" stroke-width="1.8"/>' +
+      line(x - wr, y, x + wr, y, stroke, 1.2) +
+      line(x, y - wr, x, y + wr, stroke, 1.2)
+    );
+  }
 
-  // For L1 annotation: project WP and SOT horizontally to annY row
-  const l1AnnX1 = sotX;
-  const l1AnnX2 = wpX;
-
-  // For L2 annotation: project arcEnd and l2End horizontally to annY row
-  const l2AnnX1 = arcEndX;
-  const l2AnnX2 = arcEndX + L2px; // use horizontal projection
-
-  // Large arc flag
-  const largeArc = theta > Math.PI ? 1 : 0;
-
-  // WP symbol
-  const wpR2 = 8;
-  const wpSvg =
-    '<circle cx="' +
-    f(wpX) +
-    '" cy="' +
-    f(wpY) +
-    '" r="' +
-    wpR2 +
+  // ── North arrow ───────────────────────────────────────────────────────────
+  const northTopX = wpX,
+    northTopY = wpY - northLen;
+  const northSvg =
+    line(wpX, wpY, northTopX, northTopY, CNORTH, 1.8, "6 3") +
+    '<polygon points="' +
+    f(northTopX) +
+    "," +
+    f(northTopY - 7) +
+    " " +
+    f(northTopX - 4) +
+    "," +
+    f(northTopY + 4) +
+    " " +
+    f(northTopX + 4) +
+    "," +
+    f(northTopY + 4) +
     '" fill="' +
-    white +
-    '" stroke="' +
-    stroke +
-    '" stroke-width="1.8"/>' +
-    '<line x1="' +
-    f(wpX - wpR2) +
-    '" y1="' +
-    f(wpY) +
-    '" x2="' +
-    f(wpX + wpR2) +
-    '" y2="' +
-    f(wpY) +
-    '" stroke="' +
-    stroke +
-    '" stroke-width="1.2"/>' +
-    '<line x1="' +
-    f(wpX) +
-    '" y1="' +
-    f(wpY - wpR2) +
-    '" x2="' +
-    f(wpX) +
-    '" y2="' +
-    f(wpY + wpR2) +
-    '" stroke="' +
-    stroke +
-    '" stroke-width="1.2"/>';
+    CNORTH +
+    '"/>' +
+    txt(northTopX, northTopY - 10, "0\u00b0", CNORTH, 10, "middle", false);
 
-  // Angle annotation arc
-  const tR = Math.min(VR * 0.22, 28);
-  // From inbound departure direction at WP to outbound departure direction
-  const inbDirAngle = Math.PI + halfTheta; // backward along inbound
-  const outbDirAngle = wpAngle + Math.PI / 2; // CW tangent at WP
-  const tSx = wpX + tR * Math.cos(inbDirAngle);
-  const tSy = wpY + tR * Math.sin(inbDirAngle);
-  const tEx = wpX + tR * Math.cos(outbDirAngle);
-  const tEy = wpY + tR * Math.sin(outbDirAngle);
+  // ── Angle annotation arc at WP ────────────────────────────────────────────
+  // Sweep CW from north (0° = up, touching the north arrow) to the outbound
+  // direction (touching the outbound solid line). Arc spans exactly θ.
+  const tR = Math.min(rPx * 0.28, 36);
+  const tSAng = -Math.PI / 2; // north = straight up in SVG
+  const tEAng = tSAng + theta; // CW sweep of theta → outbound direction
+  const tSx = wpX + tR * Math.cos(tSAng); // = wpX (on north arrow line)
+  const tSy = wpY + tR * Math.sin(tSAng); // = wpY - tR (above WP)
+  const tEx = wpX + tR * Math.cos(tEAng);
+  const tEy = wpY + tR * Math.sin(tEAng);
+  const tLargeArc = theta > Math.PI ? 1 : 0;
   const tArc =
     '<path d="M ' +
     f(tSx) +
@@ -405,36 +424,57 @@ function renderFlybyDiagram(L1, L2, r, theta_deg) {
     "," +
     tR +
     " 0 " +
-    largeArc +
+    tLargeArc +
     ",1 " +
     f(tEx) +
     "," +
     f(tEy) +
     '" fill="none" stroke="' +
     dim +
-    '" stroke-width="1.2"/>';
-  const tMidAngle = inbDirAngle + theta / 2;
-  const tLblX = wpX + (tR + 16) * Math.cos(tMidAngle);
-  const tLblY = wpY + (tR + 16) * Math.sin(tMidAngle);
+    '" stroke-width="1.5"/>';
+  const tMidA = tSAng + theta / 2;
+  const tLblX = wpX + (tR + 20) * Math.cos(tMidA);
+  const tLblY = wpY + (tR + 20) * Math.sin(tMidA);
 
-  // Dashed radius
-  const rMidAngle = wpAngle + theta / 2;
-  const rMidX = cx + VR * Math.cos(rMidAngle);
-  const rMidY = cy + VR * Math.sin(rMidAngle);
+  // ── MSD highlight path: SOT → arc → EOT → l2End ──────────────────────────
+  const msdPath =
+    '<path d="M ' +
+    f(sotX) +
+    "," +
+    f(sotY) +
+    " A " +
+    f(rPx) +
+    "," +
+    f(rPx) +
+    " 0 " +
+    largeArc +
+    ",1 " +
+    f(eotX) +
+    "," +
+    f(eotY) +
+    " L " +
+    f(l2EndX) +
+    "," +
+    f(l2EndY) +
+    '" fill="none" stroke="' +
+    CMSD +
+    '" stroke-width="2.5" stroke-dasharray="8 3" opacity="0.75"/>';
 
-  const svgContent =
+  // ── Assemble SVG ──────────────────────────────────────────────────────────
+  const svg =
     '<svg viewBox="0 0 ' +
     W +
     " " +
     H +
-    '" class="w-full" role="img" aria-label="Flyby MSD diagram PANS-OPS III-2-1-8" style="background:' +
+    '" class="w-full" role="img" ' +
+    'aria-label="Flyby MSD diagram PANS-OPS III-2-1-8" style="background:' +
     bg +
     ';border-radius:8px;font-family:sans-serif">\n' +
-    "<!-- Inbound track -->\n" +
+    "<!-- Inbound nominal track (\u2192 WP corner) -->\n" +
     '<path d="M ' +
-    f(inbStartX) +
+    f(inbStX) +
     "," +
-    f(inbStartY) +
+    f(inbStY) +
     " L " +
     f(wpX) +
     "," +
@@ -442,29 +482,29 @@ function renderFlybyDiagram(L1, L2, r, theta_deg) {
     '" fill="none" stroke="' +
     stroke +
     '" stroke-width="2.2" stroke-linecap="round"/>\n' +
-    "<!-- Turn arc (CW, left turn) -->\n" +
+    "<!-- Aircraft path arc (SOT→EOT, cuts the corner before WP) -->\n" +
+    '<path d="M ' +
+    f(sotX) +
+    "," +
+    f(sotY) +
+    " A " +
+    f(rPx) +
+    "," +
+    f(rPx) +
+    " 0 " +
+    largeArc +
+    ",1 " +
+    f(eotX) +
+    "," +
+    f(eotY) +
+    '" fill="none" stroke="' +
+    stroke +
+    '" stroke-width="2.2" stroke-dasharray="6 3" stroke-linecap="round"/>\n' +
+    "<!-- Outbound nominal track (from WP) -->\n" +
     '<path d="M ' +
     f(wpX) +
     "," +
     f(wpY) +
-    " A " +
-    f(VR) +
-    "," +
-    f(VR) +
-    " 0 " +
-    largeArc +
-    ",1 " +
-    f(arcEndX) +
-    "," +
-    f(arcEndY) +
-    '" fill="none" stroke="' +
-    stroke +
-    '" stroke-width="2.2" stroke-linecap="round"/>\n' +
-    "<!-- Outbound track -->\n" +
-    '<path d="M ' +
-    f(arcEndX) +
-    "," +
-    f(arcEndY) +
     " L " +
     f(outEndX) +
     "," +
@@ -472,63 +512,63 @@ function renderFlybyDiagram(L1, L2, r, theta_deg) {
     '" fill="none" stroke="' +
     stroke +
     '" stroke-width="2.2" stroke-linecap="round"/>\n' +
+    "<!-- MSD path highlight -->\n" +
+    msdPath +
+    "\n" +
     "<!-- Dashed radius -->\n" +
-    dashLine(cx, cy, rMidX, rMidY, dim) +
+    line(cX, cY, rMidX, rMidY, dim, 1, "5 3") +
     "\n" +
     txt(
-      cx + (rMidX - cx) * 0.55 + 8,
-      cy + (rMidY - cy) * 0.55,
+      cX + (rMidX - cX) * 0.58 + 8,
+      cY + (rMidY - cY) * 0.58,
       "r",
       dim,
       11,
       "start",
-      true,
+      false,
     ) +
+    "\n" +
+    "<!-- M dimension (MSD total, shown along inbound) -->\n" +
+    dimLine(sotX, sotY, wpX, wpY, CL1, "M", (L1 + L2).toFixed(3) + " NM", -26) +
+    "\n" +
+    "<!-- North arrow -->\n" +
+    northSvg +
     "\n" +
     "<!-- WP symbol -->\n" +
-    wpSvg +
+    wpSym(wpX, wpY) +
     "\n" +
-    "<!-- Theta annotation -->\n" +
+    "<!-- Angle arc -->\n" +
     tArc +
     "\n" +
-    txt(
-      tLblX,
-      tLblY + 4,
-      "\u03b8 = " + theta_deg + "\u00b0",
-      dim,
-      10,
-      "middle",
-      true,
-    ) +
+    txt(tLblX, tLblY + 4, theta_deg + "\u00b0", dim, 10, "middle", false) +
     "\n" +
-    "<!-- Drop lines for dimension row -->\n" +
-    dashLine(sotX, sotY, l1AnnX1, annY - 18, dim, 0.7, "3 3") +
+    "<!-- MSD label box -->\n" +
+    '<rect x="' +
+    f(PAD_L) +
+    '" y="' +
+    f(PAD_T) +
+    '" width="110" height="22" rx="4" fill="' +
+    CMSD +
+    '" fill-opacity="0.12" stroke="' +
+    CMSD +
+    '" stroke-width="1"/>\n' +
+    txt(PAD_L + 55, PAD_T + 15, "MSD = L1 + L2", CMSD, 11, "middle", true) +
     "\n" +
-    dashLine(wpX, wpY, l1AnnX2, annY - 18, dim, 0.7, "3 3") +
-    "\n" +
-    dashLine(arcEndX, arcEndY, l2AnnX1, annY - 18, dim, 0.7, "3 3") +
-    "\n" +
-    dashLine(l2EndX, l2EndY, l2AnnX2, annY - 18, dim, 0.7, "3 3") +
-    "\n" +
-    "<!-- L1 dimension -->\n" +
-    hArrow(l1AnnX1, l1AnnX2, annY, CL1, "L1", L1.toFixed(3) + " NM") +
-    "\n" +
-    "<!-- L2 dimension -->\n" +
-    hArrow(l2AnnX1, l2AnnX2, annY, CL2, "L2", L2.toFixed(3) + " NM") +
-    "\n" +
-    "<!-- MSD total -->\n" +
+    "<!-- Total -->\n" +
     '<text x="' +
     f(W / 2) +
     '" y="' +
-    f(H - 12) +
-    '" text-anchor="middle" font-size="12" font-weight="700" fill="' +
+    f(H - 14) +
+    '" text-anchor="middle" font-size="12" ' +
+    'font-weight="700" fill="' +
     textC +
-    '" font-family="monospace">M = L1 + L2 = ' +
+    '" font-family="monospace">' +
+    "M = L1 + L2 = " +
     (L1 + L2).toFixed(4) +
     " NM</text>\n" +
     "</svg>";
 
-  container.innerHTML = svgContent;
+  container.innerHTML = svg;
   diagramSection.classList.remove("hidden");
 }
 
@@ -539,6 +579,7 @@ function saveParameters() {
     ias: document.getElementById("ias").value || "",
     altitude: document.getElementById("altitude").value || "",
     altitudeUnit: document.getElementById("altitudeUnit").value || "ft",
+    isaDeviation: document.getElementById("isaDeviation").value || "",
     bankAngle: document.getElementById("bankAngle").value || "",
     turnAngle: document.getElementById("turnAngle").value || "",
   };
@@ -580,6 +621,8 @@ function loadParameters(event) {
         document.getElementById("bankAngle").value = data.bankAngle;
       if (data.turnAngle !== undefined)
         document.getElementById("turnAngle").value = data.turnAngle;
+      if (data.isaDeviation !== undefined)
+        document.getElementById("isaDeviation").value = data.isaDeviation;
       showToast("Parameters loaded.", "success");
     } catch {
       showToast("Invalid JSON file.", "error");
@@ -592,8 +635,10 @@ function loadParameters(event) {
 // --- Copy to Word -------------------------------------------------------------
 
 function copyToWord() {
-  const mVal = document.getElementById("outM").textContent;
-  if (!mVal) return;
+  if (_raw.M === undefined) return;
+
+  const exact = document.getElementById("copyPrecision").value === "exact";
+  const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
@@ -601,16 +646,21 @@ function copyToWord() {
       document.getElementById("altitude").value +
       " " +
       document.getElementById("altitudeUnit").value,
-    "k Factor": document.getElementById("outKFactor").textContent,
+    "ISA Deviation (VAR)":
+      document.getElementById("isaDeviation").value + " \u00b0C",
+    "k Factor": fmt(_raw.kFactor),
     "Bank Angle": document.getElementById("bankAngle").value + "\u00b0",
     "Turn Angle A": document.getElementById("outTurnUsed").textContent,
-    TAS: document.getElementById("outTas").textContent + " KT",
-    "Radius (r)": document.getElementById("outR").textContent + " NM",
-    "L1 = r x tan(A/2)": document.getElementById("outL1").textContent + " NM",
-    "L2 = 5 x V/3600": document.getElementById("outL2").textContent + " NM",
-    "M (Flyby MSD)": mVal + " NM",
+    TAS: fmt(_raw.tas) + " KT",
+    "Radius (r)": fmt(_raw.r) + " NM",
+    "L1 = r x tan(A/2)": fmt(_raw.L1) + " NM",
+    "L2 = 5 x V/3600": fmt(_raw.L2) + " NM",
+    "M (Flyby MSD)": fmt(_raw.M) + " NM",
   };
 
-  const htmlContent = createHTMLTable(tableData, "Flyby MSD � PANS-OPS S1.4.2");
+  const htmlContent = createHTMLTable(
+    tableData,
+    "Flyby MSD \u2014 PANS-OPS S1.4.2",
+  );
   copyToClipboard(htmlContent);
 }


### PR DESCRIPTION
# feat(#69): Flyby Calculator — ISA Deviation Input, Corrected Diagram & Precision Toggle
---

## Summary

Three improvements to the existing **Flyby MSD Calculator** (PANS-OPS Vol II §III-2-1-8):

1. **ISA deviation is now a user input** — the hardcoded `+15 °C` has been removed; the user provides the actual ISA deviation (VAR), defaulting to `0` when left blank.
2. **Geometrically correct PANS-OPS flyby diagram** — complete rewrite of `renderFlybyDiagram()` to accurately represent a fly-by waypoint: the arc cuts the corner _before_ the WP, two nominal reference lines intersect at the WP crosshair, and the angle annotation is anchored to both lines.
3. **Display precision toggle + Copy to Word** — a split-button control lets the user switch result cards between **Rounded (4 decimal places)** and **Exact (full JS floating-point)**, with the same precision applied to the copied Word table.

---

## Problem

| #                | Before                                                                          | After                                                                                                                    |
| ---------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| ISA input        | `calculateKFactor(altitude_ft, 15)` — hardcoded +15 °C                          | User-supplied ISA deviation field; empty = 0 °C (ISA standard)                                                           |
| Diagram geometry | Arc started **at WP** (fly-over behavior); angle arc swept from wrong reference | Arc starts at **SOT** (before WP); WP is the nominal corner intersection; angle arc spans from 0° north to outbound line |
| Copy precision   | All values copied at `.toFixed(4)` with no user control                         | Dropdown: Rounded (4 dec.) or Exact; cards update live; copied table matches display                                     |

---

## Changes

### `html/Flyby_Calculation.html`

- **Input grid:** changed from `md:grid-cols-2` to `md:grid-cols-3` to add the ISA deviation column.
- **New input field:** `#isaDeviation` (type number, step 0.1, optional — blank treated as 0 °C) with i18n label and placeholder.
- **Removed:** static "ISA +15 °C note" block (`data-i18n="flyby.isaNote"`).
- **Copy control:** replaced the standalone button with a unified split-button:
  - Left side: `<select id="copyPrecision">` — Rounded / Exact options, custom-styled with hidden chevron.
  - Right side: `<button id="btnCopy">` — Copy to Word, fused visually via shared border and `overflow-hidden`.

### `html/js/flyby_calculation.js`

#### `calculateFlyby()`

- Reads `#isaDeviation`; defaults to `0` when empty; validates with `isNaN` guard.
- Passes `isaDeviation` to `calculateKFactor(altitude_ft, isaDeviation)` instead of the hardcoded `15`.
- Stores all computed values in `_raw` object and calls `applyDisplayPrecision()` to render cards.

#### `applyDisplayPrecision()` — new function

Reads the `#copyPrecision` select and updates all result `<span>` elements:

```js
const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
```

Called on `change` event of the select and after every calculation.

#### `_raw` — new module-level store

```js
const _raw = {}; // { kFactor, tas, r, L1, L2, M }
```

Populated after each successful calculation. Avoids re-parsing DOM text for the copy function.

#### `copyToWord()`

- Guards on `_raw.M === undefined` instead of checking the DOM.
- Formats values using `_raw.*` directly — no `parseFloat(element.textContent)` round-trip.
- Fixed garbled title character (`Flyby MSD — PANS-OPS S1.4.2` with proper em dash U+2014).

#### `renderFlybyDiagram()` — full geometry rewrite

**Coordinate system:**

```
WP = (0, 0)  — nominal corner intersection (aircraft does NOT reach this)
Inbound  = north = straight down from WP  →  direction (0, +1) in NM
Outbound = lower-right at angle θ          →  direction (sin θ, −cos θ)
```

**Key NM geometry:**
| Variable | Formula | Description |
|----------|---------|-------------|
| `sotNM` | `[0, L1]` | Start of Turn — on inbound, L1 below WP |
| `cNM` | `[r, L1]` | Arc center — right of SOT by radius r |
| `sotAng` | `π` | Angle from center to SOT |
| `eotAng` | `π + θ` | Angle from center to EOT |
| `oDX / oDY` | `sin θ, −cos θ` | Outbound unit vector |
| `l2EndNM` | `EOT + L2 × outbound` | BRAVO point (L2 end) |

**Elements drawn:**

1. Inbound nominal track (straight line → WP)
2. Outbound nominal track (straight line WP →, solid)
3. Aircraft path arc (SOT → EOT, dashed stroke — actual flight path)
4. MSD orange dashed highlight (arc + L2 segment)
5. M dimension line along inbound (SOT → WP), labeled with total MSD value
6. Dashed radius line to arc midpoint with "r" label
7. North arrow (dashed, blue, 64 px above WP, "0°" label)
8. WP crosshair symbol at corner intersection
9. Angle arc at WP — sweeps from −π/2 (north, touching north arrow) CW by θ to outbound direction (touching outbound line)
10. θ° label at arc midpoint
11. MSD label box (orange, top-left): "MSD = L1 + L2"
12. Total line (bottom): "M = L1 + L2 = X.XXXX NM"

**Canvas:** 860 × 460 px. WP is positioned with `dimLeftPad = 60 px` reserved to the left for the M label, then centered horizontally.

#### `saveParameters()` / `loadParameters()`

Both updated to include `isaDeviation` field in the JSON save/restore payload.

### `html/i18n/en.json` / `es.json`

| Key                     | EN                       | ES                            |
| ----------------------- | ------------------------ | ----------------------------- |
| `flyby.isaDeviationVar` | `ISA Deviation (VAR) °C` | `Desviación ISA (VAR) °C`     |
| `flyby.phIsaDeviation`  | `e.g. 15`                | `ej. 15`                      |
| `common.copyRounded`    | `Rounded (4 dec.)`       | `Redondeado (4 dec.)`         |
| `common.copyExact`      | `Exact`                  | `Exacto (precisión completa)` |
| `flyby.isaNote`         | _(removed)_              | _(removed)_                   |

---

## Diagram Geometry Notes

Full documentation of the flyby diagram geometry, coordinate system, and errors found during development is in [`docs/flyby-diagram-geometry.md`](flyby-diagram-geometry.md).

Key insight: a **fly-by** waypoint is a _corner intersection_, not an arc start. The arc cuts the corner before the WP. Earlier versions incorrectly drew the arc starting at the WP (fly-over behavior). The correct implementation:

- Arc: **SOT → EOT** (before and after the WP corner)
- WP crosshair: at the **nominal intersection** of both straight tracks
- Angle arc: both endpoints **touch** their respective reference lines (north arrow & outbound)

---

## Testing Checklist

- [ ] IAS = 250 kt, Alt = 4000 ft, Bank = 25°, Turn = 105°, ISA = +15 °C → M ≈ 3.3978 NM
- [ ] ISA field blank → same as ISA = 0 (standard atmosphere)
- [ ] ISA = −20 °C → lower TAS → shorter MSD
- [ ] Turn angle < 50° → clamped to 50° + warning banner shown
- [ ] Precision toggle → all cards update immediately, no recalculation needed
- [ ] Copy (Rounded) → table values at 4 decimal places
- [ ] Copy (Exact) → table values match full JS float string
- [ ] Save / Load JSON → `isaDeviation` field persists and restores
- [ ] Dark mode → diagram colors and cards render correctly
- [ ] Language toggle EN ↔ ES → all new keys translate correctly

## Problem Description

### 1 — Hardcoded ISA +15 °C

The IAS → TAS conversion (`calculateKFactor`) received a constant `15` as the ISA deviation:

```js
// BEFORE (main)
const kFactor = calculateKFactor(altitude_ft, 15);
```

Per PANS-OPS the ISA deviation depends on the procedure location and season; the designer must supply the value. Hardcoding 15 produced incorrect TAS, radius, and MSD results for non-standard conditions.

A static informational note was displayed below the inputs:

```html
<!-- BEFORE -->
<p data-i18n="flyby.isaNote">
  ISA +15°C applied per PANS-OPS procedure design standard (§1.4.1)
</p>
```

### 2 — Rounding in intermediate calculations

The review comment flagged a pattern seen previously in the Flyover calculator: intermediate values being rounded with `.toFixed()` before being passed to the next calculation step, introducing cumulative numeric error.

Inspection of `flyby_calculation.js` confirmed:

```
kFactor  →  tas  →  r  →  L1, L2  →  M
```

Each step assigns directly to a `const` holding the full-precision `number` returned by the utility function or arithmetic expression. **`.toFixed(4)` appears only on `textContent` assignments**, never inside the calculation chain. The rounding concern was therefore already resolved structurally, but this PR makes the intent explicit and removes any ambiguity for future maintainers.

---

## Changes

### `html/Flyby_Calculation.html`

| Area             | Before                    | After                                                            |
| ---------------- | ------------------------- | ---------------------------------------------------------------- |
| Input row layout | 2-column grid             | 3-column grid                                                    |
| ISA input        | Absent (hardcoded)        | `<input id="isaDeviation">` with step 0.1, placeholder "e.g. 15" |
| Static ISA note  | Present (`flyby.isaNote`) | Removed                                                          |

### `html/js/flyby_calculation.js`

**`calculateFlyby()`**

```js
// AFTER — reads ISA from input; defaults to 0 (ISA standard) if left empty
const isaDeviationRaw = document.getElementById("isaDeviation").value;
const isaDeviation = isaDeviationRaw === "" ? 0 : parseFloat(isaDeviationRaw);

if (isNaN(isaDeviation)) {
  showToast("Please enter a valid ISA deviation.", "error");
  return;
}

const kFactor = calculateKFactor(altitude_ft, isaDeviation); // was: 15
```

**Calculation chain — rounding policy**

```js
// CORRECT: exact values throughout, rounding only at display
const kFactor = calculateKFactor(altitude_ft, isaDeviation); // full precision
const tas = calculateTAS(iasVal, kFactor); // full precision
const r = calculateRadius(tas, bankAngleVal); // full precision
const L1 = r * Math.tan(turnHalf_rad); // full precision
const L2 = (5 * tas) / 3600; // full precision
const M = L1 + L2; // full precision

// Display only:
document.getElementById("outKFactor").textContent = kFactor.toFixed(4);
document.getElementById("outTas").textContent = tas.toFixed(4);
document.getElementById("outR").textContent = r.toFixed(4);
document.getElementById("outL1").textContent = L1.toFixed(4);
document.getElementById("outL2").textContent = L2.toFixed(4);
document.getElementById("outM").textContent = M.toFixed(4);
```

**`saveParameters()` / `loadParameters()`** — `isaDeviation` field added to persist/restore the value across sessions.

**`copyToWord()`** — added `"ISA Deviation (VAR)": isaDeviation + " °C"` row.

### `html/i18n/en.json` + `es.json`

| Key                     | Action                            |
| ----------------------- | --------------------------------- |
| `flyby.isaDeviationVar` | Added — label for new input       |
| `flyby.phIsaDeviation`  | Added — placeholder for new input |
| `flyby.isaNote`         | Removed — no longer applicable    |

---

## Behaviour Reference

| Stage                 | Precision                       | Note                               |
| --------------------- | ------------------------------- | ---------------------------------- |
| `calculateKFactor`    | Full JS float (~15 sig. digits) | Uses ISA deviation from input      |
| `calculateTAS`        | Full JS float                   | No rounding of kFactor before use  |
| `calculateRadius`     | Full JS float                   | No rounding of TAS before use      |
| L1, L2, M arithmetic  | Full JS float                   | No rounding of r before use        |
| Display (textContent) | 4 decimal places                | `.toFixed(4)` — display only       |
| SVG diagram labels    | 3–4 decimal places              | `.toFixed(3/4)` on text nodes only |

---

## Testing Checklist

- [ ] ISA deviation input accepts positive and negative values (cold/hot atmosphere)
- [ ] Leaving ISA deviation blank defaults to 0 (ISA standard atmosphere) without error
- [ ] Invalid ISA (e.g. letters) shows error toast and does not calculate
- [ ] Results change when ISA deviation changes (with same IAS, altitude, angles)
- [ ] MSD value matches PANS-OPS reference table for known ISA + IAS + altitude combinations
- [ ] Save/Load restores ISA deviation value correctly
- [ ] Copy to Word output includes ISA Deviation row
- [ ] Language switch (EN/ES) applies correct label and placeholder
- [ ] Turn angle < 50° is adjusted to 50° with warning banner (unchanged)
