### PR TITLE
Fix/81 radius rate of turn cap

### DIFF
--- a/html/aviation-utils.js
+++ b/html/aviation-utils.js
@@ -114,9 +114,7 @@ function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
   const rateOfTurn = calculateRateOfTurn(tas, radius);
   const rateOfTurnCapped = Math.min(rateOfTurn, 3);
   const radiusForCalc =
-    rateOfTurnCapped < rateOfTurn
-      ? tas / (111.95 * rateOfTurnCapped)
-      : radius;
+    rateOfTurnCapped < rateOfTurn ? tas / (111.95 * rateOfTurnCapped) : radius;
 
   return {
     radius,

--- a/html/aviation-utils.js
+++ b/html/aviation-utils.js
@@ -89,6 +89,44 @@ function calculateRadius(tas, bankAngle_deg) {
 }
 
 /**
+ * Calculates the rate of turn (PANS-OPS Vol II)
+ * @param {number} tas - True Airspeed in knots
+ * @param {number} radius_nm - Radius of turn in nautical miles
+ * @return {number} Rate of turn in degrees per second
+ */
+function calculateRateOfTurn(tas, radius_nm) {
+  return tas / (111.95 * radius_nm);
+}
+
+/**
+ * Calculates radius of turn with Rate of Turn cap (max 3°/s per PANS-OPS Vol II)
+ * If calculated rate of turn > 3°/s, uses 3°/s to calculate the radius instead
+ * @param {number} tas - True Airspeed in knots
+ * @param {number} bankAngle_deg - Bank angle in degrees
+ * @return {object} Object with { radius, rateOfTurn, rateOfTurnCapped, radiusForCalc }
+ *   - radius: uncapped radius
+ *   - rateOfTurn: calculated rate of turn
+ *   - rateOfTurnCapped: min(rateOfTurn, 3)
+ *   - radiusForCalc: radius to use for further calculations (uses capped rate)
+ */
+function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
+  const radius = calculateRadius(tas, bankAngle_deg);
+  const rateOfTurn = calculateRateOfTurn(tas, radius);
+  const rateOfTurnCapped = Math.min(rateOfTurn, 3);
+  const radiusForCalc =
+    rateOfTurnCapped < rateOfTurn
+      ? tas / (111.95 * rateOfTurnCapped)
+      : radius;
+
+  return {
+    radius,
+    rateOfTurn,
+    rateOfTurnCapped,
+    radiusForCalc,
+  };
+}
+
+/**
  * Calculates the flight distance (d)
  * @param {number} tasPlusWind - TAS plus wind in knots
  * @return {number} Flight distance in nautical miles

--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -25,6 +25,32 @@ if (typeof calculateRadius === "undefined") {
     return (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB2));
   }
 }
+if (typeof calculateRateOfTurn === "undefined") {
+  // eslint-disable-next-line no-unused-vars
+  function calculateRateOfTurn(tas, radius_nm) {
+    return tas / (111.95 * radius_nm);
+  }
+}
+if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
+  var _DEG_TO_RAD_FB3 = Math.PI / 180;
+  // eslint-disable-next-line no-unused-vars
+  function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
+    var radius =
+      (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB3));
+    var rateOfTurn = tas / (111.95 * radius);
+    var rateOfTurnCapped = Math.min(rateOfTurn, 3);
+    var radiusForCalc =
+      rateOfTurnCapped < rateOfTurn
+        ? tas / (111.95 * rateOfTurnCapped)
+        : radius;
+    return {
+      radius: radius,
+      rateOfTurn: rateOfTurn,
+      rateOfTurnCapped: rateOfTurnCapped,
+      radiusForCalc: radiusForCalc,
+    };
+  }
+}
 
 // Raw results store — populated after each calculation
 const _raw = {};
@@ -139,8 +165,9 @@ function calculateFlyby() {
   const kFactor = calculateKFactor(altitude_ft, isaDeviation);
   const tas = calculateTAS(iasVal, kFactor);
 
-  // --- Radius ---
-  const r = calculateRadius(tas, bankAngleVal);
+  // --- Radius (with rate of turn cap: max 3°/s per PANS-OPS) ---
+  const radiusObj = calculateRadiusWithRateOfTurnCap(tas, bankAngleVal);
+  const r = radiusObj.radiusForCalc;
 
   // --- Flyby MSD (PANS-OPS S1.4.2.1) ---
   // L1 = r x tan(A/2)

--- a/html/js/flyover_calculation.js
+++ b/html/js/flyover_calculation.js
@@ -25,6 +25,32 @@ if (typeof calculateRadius === "undefined") {
     return (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB));
   }
 }
+if (typeof calculateRateOfTurn === "undefined") {
+  // eslint-disable-next-line no-unused-vars
+  function calculateRateOfTurn(tas, radius_nm) {
+    return tas / (111.95 * radius_nm);
+  }
+}
+if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
+  var _DEG_TO_RAD_FB2 = Math.PI / 180;
+  // eslint-disable-next-line no-unused-vars
+  function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
+    var radius =
+      (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB2));
+    var rateOfTurn = tas / (111.95 * radius);
+    var rateOfTurnCapped = Math.min(rateOfTurn, 3);
+    var radiusForCalc =
+      rateOfTurnCapped < rateOfTurn
+        ? tas / (111.95 * rateOfTurnCapped)
+        : radius;
+    return {
+      radius: radius,
+      rateOfTurn: rateOfTurn,
+      rateOfTurnCapped: rateOfTurnCapped,
+      radiusForCalc: radiusForCalc,
+    };
+  }
+}
 
 // Initialize on page load
 document.addEventListener("DOMContentLoaded", function () {
@@ -179,9 +205,11 @@ function calculateFlyover() {
   const kFactor = calculateKFactor(altitude_ft, isaDeviation);
   const tas = calculateTAS(iasVal, kFactor);
 
-  // --- Radii ---
-  const r1 = calculateRadius(tas, bankAngleVal); // roll-in (user bank)
-  const r2 = calculateRadius(tas, 15); // roll-out fixed 15° §1.4.1.3
+  // --- Radii (with rate of turn cap: max 3°/s per PANS-OPS) ---
+  const r1Obj = calculateRadiusWithRateOfTurnCap(tas, bankAngleVal); // roll-in (user bank)
+  const r1 = r1Obj.radiusForCalc;
+  const r2Obj = calculateRadiusWithRateOfTurnCap(tas, 15); // roll-out fixed 15° §1.4.1.3
+  const r2 = r2Obj.radiusForCalc;
 
   // --- Segment lengths (PANS-OPS Vol II §1.4.1) ---
   const ALPHA_DEG = 30;

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -18,6 +18,29 @@ if (typeof calculateRadius === "undefined") {
     return (tas * tas) / (68625 * Math.tan(bankAngle_deg * DEG_TO_RAD));
   };
 }
+if (typeof calculateRateOfTurn === "undefined") {
+  var calculateRateOfTurn = function (tas, radius_nm) {
+    return tas / (111.95 * radius_nm);
+  };
+}
+if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
+  var calculateRadiusWithRateOfTurnCap = function (tas, bankAngle_deg) {
+    var DEG_TO_RAD = Math.PI / 180;
+    var radius = (tas * tas) / (68625 * Math.tan(bankAngle_deg * DEG_TO_RAD));
+    var rateOfTurn = tas / (111.95 * radius);
+    var rateOfTurnCapped = Math.min(rateOfTurn, 3);
+    var radiusForCalc =
+      rateOfTurnCapped < rateOfTurn
+        ? tas / (111.95 * rateOfTurnCapped)
+        : radius;
+    return {
+      radius: radius,
+      rateOfTurn: rateOfTurn,
+      rateOfTurnCapped: rateOfTurnCapped,
+      radiusForCalc: radiusForCalc,
+    };
+  };
+}
 
 // Module-level stored results for copy-to-word
 var _raw1 = null;
@@ -189,7 +212,8 @@ function computeFlyby(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
   var DEG_TO_RAD = Math.PI / 180;
   var kFactor = calculateKFactor(altitude_ft, isaDeviation);
   var tas = calculateTAS(ias, kFactor);
-  var r = calculateRadius(tas, bankAngle);
+  var rObj = calculateRadiusWithRateOfTurnCap(tas, bankAngle);
+  var r = rObj.radiusForCalc;
   var effectiveTurn = Math.max(turnAngle, 50);
   var minApplied = effectiveTurn !== turnAngle;
   var L1 = r * Math.tan((effectiveTurn / 2) * DEG_TO_RAD);
@@ -212,8 +236,10 @@ function computeFlyover(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
   var DEG_TO_RAD = Math.PI / 180;
   var kFactor = calculateKFactor(altitude_ft, isaDeviation);
   var tas = calculateTAS(ias, kFactor);
-  var r1 = calculateRadius(tas, bankAngle);
-  var r2 = calculateRadius(tas, 15); // fixed 15° roll-out bank per §1.4.1.3
+  var r1Obj = calculateRadiusWithRateOfTurnCap(tas, bankAngle);
+  var r1 = r1Obj.radiusForCalc;
+  var r2Obj = calculateRadiusWithRateOfTurnCap(tas, 15); // fixed 15° roll-out bank per §1.4.1.3
+  var r2 = r2Obj.radiusForCalc;
   var theta_rad = turnAngle * DEG_TO_RAD;
   var alpha_rad = 30 * DEG_TO_RAD;
   var L1fo = r1 * Math.sin(theta_rad);


### PR DESCRIPTION
# fix(#81): Apply 3°/s Rate of Turn cap to radius calculations
---

## Summary

Per PANS-OPS Vol II, when calculating the rate of turn (R), if the value exceeds 3°/s, then 3°/s must be used for turn radius calculations instead. This rule was not being applied in the Flyby, Flyover, and MSD Combined calculators.

**Before:** All three calculators computed radius directly using bank angle:
$$r = \frac{V^2}{68625 \times \tan(\text{bank})}$$

**After:** Rate of turn is calculated first:
$$R = \frac{V}{111.95 \times r}$$

If $R > 3°/s$, then use:
$$r_{\text{capped}} = \frac{V}{111.95 \times 3}$$

for all subsequent MSD calculations.

---

## Changes

### `html/aviation-utils.js` — New functions

Added two new shared functions:

1. **`calculateRateOfTurn(tas, radius_nm)`**
   - Calculates rate of turn in degrees per second
   - Formula: `R = TAS / (111.95 × radius)`

2. **`calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg)`**
   - Calculates radius using the capped rate of turn
   - Returns object: `{ radius, rateOfTurn, rateOfTurnCapped, radiusForCalc }`
   - `radiusForCalc` is the value to use for MSD calculations

### `html/js/flyby_calculation.js`

- Added fallback functions for standalone execution
- Updated `calculateFlyby()` to use `calculateRadiusWithRateOfTurnCap()`
- Now uses `radiusObj.radiusForCalc` instead of direct `calculateRadius()` call

### `html/js/flyover_calculation.js`

- Added fallback functions for standalone execution
- Updated `calculateFlyover()` to compute both r₁ and r₂ with rate of turn cap
  - r₁: roll-in radius (user-specified bank angle)
  - r₂: roll-out radius (fixed 15° bank per §1.4.1.3)

### `html/js/msd_calculation.js`

- Added fallback functions for standalone execution
- Updated `computeFlyby()` to use capped radius
- Updated `computeFlyover()` to use capped radius for both r₁ and r₂

---

## Example Correction

**Scenario from issue #81:**

- IAS = 125 KT
- Altitude = 1000 ft
- Bank Angle = 25°

**Before (incorrect):**

- Rate of Turn R = 3.9134°/s
- Radius r = 0.6904 NM (calculated from 3.9134)
- MSD based on r = 0.6904 NM

**After (correct):**

- Rate of Turn R = 3.9134°/s (calculated)
- Rate of Turn Capped = 3.0°/s (applied to radius)
- Radius for calc r = 0.3876 NM (calculated from 3.0°/s)
- MSD based on r = 0.3876 NM

---

## Code Pattern

All three calculators now follow this pattern:

```javascript
// With rate of turn cap
const radiusObj = calculateRadiusWithRateOfTurnCap(tas, bankAngle);
const rForCalc = radiusObj.radiusForCalc; // Use this for MSD formulas

// Returns object with:
// {
//   radius,           // Uncapped radius
//   rateOfTurn,       // Calculated R in deg/s
//   rateOfTurnCapped, // min(R, 3)
//   radiusForCalc     // Radius to use for calculations
// }
```

---

## Testing

Test with inputs that trigger the cap (R > 3°/s):

- Low altitude + high TAS + shallow bank
- Verify R shows > 3.0°/s
- Verify radius calculation uses min(R, 3) = 3.0°/s

Test with inputs that don't trigger the cap (R ≤ 3°/s):

- High altitude or lower TAS
- Verify R ≤ 3.0°/s
- Verify radius calculation uses actual R value (no change)

---

## Files Changed

| File                             | Change                                                                 |
| -------------------------------- | ---------------------------------------------------------------------- |
| `html/aviation-utils.js`         | Added `calculateRateOfTurn()` and `calculateRadiusWithRateOfTurnCap()` |
| `html/js/flyby_calculation.js`   | Use capped radius in Flyby formula                                     |
| `html/js/flyover_calculation.js` | Use capped radius for r₁ and r₂                                        |
| `html/js/msd_calculation.js`     | Use capped radius in both compute functions                            |
