### PR TITLE
feat(#80): Flyby and Flyover MSD — Rate of Turn in Copy to Word

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ REDESIGN_PLAN.md
 .agent/
 .agents/
 .claude/
+CLAUDE.md
 skills-lock.json

--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -640,6 +640,8 @@ function copyToWord() {
   const exact = document.getElementById("copyPrecision").value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
+  var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 60;
+
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
     "Altitude h1":
@@ -652,6 +654,7 @@ function copyToWord() {
     "Bank Angle": document.getElementById("bankAngle").value + "\u00b0",
     "Turn Angle A": document.getElementById("outTurnUsed").textContent,
     TAS: fmt(_raw.tas) + " KT",
+    "Rate of turn (R)": fmt(rateOfTurn) + " \u00b0/min",
     "Radius (r)": fmt(_raw.r) + " NM",
     "L1 = r x tan(A/2)": fmt(_raw.L1) + " NM",
     "L2 = 5 x V/3600": fmt(_raw.L2) + " NM",

--- a/html/js/flyover_calculation.js
+++ b/html/js/flyover_calculation.js
@@ -610,6 +610,9 @@ function copyToWord() {
     document.getElementById("copyPrecision").dataset.value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
+  var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 60;
+  var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 60;
+
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
     "Altitude h1":
@@ -622,7 +625,9 @@ function copyToWord() {
     "Bank Angle r1": document.getElementById("bankAngle").value + "°",
     "Turn Angle (input)": document.getElementById("turnAngle").value + "°",
     TAS: fmt(_raw.tas) + " KT",
+    "R1": fmt(rateR1) + " °/min",
     "Turn Angle Used": document.getElementById("outThetaEff").textContent,
+    "R2": fmt(rateR2) + " °/min",
     "r1 (roll-in)": fmt(_raw.r1) + " NM",
     "r2 (roll-out, 15° fixed)": fmt(_raw.r2) + " NM",
     L1: fmt(_raw.L1) + " NM",


### PR DESCRIPTION
# feat(#80): Flyby and Flyover MSD — Rate of Turn in Copy to Word

## Summary

The Copy to Word output tables for Flyby MSD and Flyover MSD now include Rate of Turn rows at the positions required by the PANS-OPS documentation workflow.

Formula: **ROT (°/min) = (TAS / r) × (180 / π) / 60** — derived directly from the already-computed radius and TAS stored in `_raw`.

---

## Changes

### `html/js/flyby_calculation.js` — `copyToWord()`

| Position | Before | After |
|---|---|---|
| Between TAS and Radius (r) | — | `Rate of turn (R)` row added |

New row label: `Rate of turn (R)`, value: formatted °/min.

### `html/js/flyover_calculation.js` — `copyToWord()`

| Position | Before | After |
|---|---|---|
| Between TAS and Turn Angle Used | — | `R1` row added |
| Between Turn Angle Used and r1 (roll-in) | — | `R2` row added |

- `R1` = rate of turn for roll-in radius (user bank angle)
- `R2` = rate of turn for roll-out radius (fixed 15°)

---

## Final table order

### Flyby MSD

```
IAS
Altitude h1
ISA Deviation (VAR)
k Factor
Bank Angle
Turn Angle A
TAS
Rate of turn (R)   ← new
Radius (r)
L1 = r x tan(A/2)
L2 = 5 x V/3600
M (Flyby MSD)
```

### Flyover MSD

```
IAS
Altitude h1
ISA Deviation (VAR)
k Factor
Bank Angle r1
Turn Angle (input)
TAS
R1                     ← new
Turn Angle Used
R2                     ← new
r1 (roll-in)
r2 (roll-out, 15° fixed)
L1 … L5 (bank establishment)
MSD Total
```

---

## Testing checklist

- [ ] Flyby: Calculate → Copy to Word → paste into Word — "Rate of turn (R)" appears between TAS and Radius (r)
- [ ] Flyby: Exact and Rounded precision modes both format the rate of turn value correctly
- [ ] Flyover: Calculate → Copy to Word → paste into Word — "R1" appears after TAS, "R2" appears after Turn Angle Used
- [ ] Flyover: R2 reflects 15° fixed bank (numerically larger ROT than R1 for same TAS, since r2 > r1)
- [ ] No change to the on-screen result display (only Copy to Word affected)

---

## Files Changed

| File | Change |
|---|---|
| `html/js/flyby_calculation.js` | +3 lines in `copyToWord()` |
| `html/js/flyover_calculation.js` | +4 lines in `copyToWord()` |
