### PR TITLE
fix(#80): correct rate-of-turn formula 

### DIFF
--- a/html/Flyby_Calculation.html
+++ b/html/Flyby_Calculation.html
@@ -357,8 +357,8 @@
           MSD Results
         </h2>
 
-        <!-- Intermediate values: kFactor, TAS, TurnUsed, Radius -->
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+        <!-- Intermediate values: kFactor, TAS, TurnUsed, RateOfTurn, Radius -->
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
           <div
             class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
           >
@@ -400,6 +400,20 @@
             <p class="text-base font-semibold dark:text-white">
               <span id="outTurnUsed"></span>
               <span class="text-sm font-normal">°</span>
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-xs text-gray-500 dark:text-gray-400"
+              data-i18n="flyby.rateOfTurn"
+            >
+              Rate of Turn (R)
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outRateOfTurn"></span>
+              <span class="text-sm font-normal">°/s</span>
             </p>
           </div>
           <div

--- a/html/Flyover_Calculation.html
+++ b/html/Flyover_Calculation.html
@@ -382,7 +382,7 @@
         </h2>
 
         <!-- Intermediate values: kFactor, TAS, turn angle used, r1, r2 -->
-        <div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-2">
           <div
             class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
           >
@@ -458,6 +458,36 @@
               <span class="text-sm font-normal" data-i18n="common.nauticalMiles"
                 >NM</span
               >
+            </p>
+          </div>
+        </div>
+
+        <!-- Rate of turn row: R1 (roll-in) and R2 (roll-out) -->
+        <div class="grid grid-cols-2 gap-3 mb-4">
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-xs text-gray-500 dark:text-gray-400"
+              data-i18n="flyover.rateOfTurnR1"
+            >
+              Rate of Turn R1 (roll-in)
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outRot1"></span>
+              <span class="text-sm font-normal">°/s</span>
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              <span data-i18n="flyover.rateOfTurnR2">Rate of Turn R2</span>
+              <span class="ml-1 text-gray-400 dark:text-gray-500 text-xs" data-i18n="flyover.r2Fixed">(15° fixed)</span>
+            </p>
+            <p class="text-base font-semibold dark:text-white">
+              <span id="outRot2"></span>
+              <span class="text-sm font-normal">°/s</span>
             </p>
           </div>
         </div>

--- a/html/aviation-utils.js
+++ b/html/aviation-utils.js
@@ -95,7 +95,8 @@ function calculateRadius(tas, bankAngle_deg) {
  * @return {number} Rate of turn in degrees per second
  */
 function calculateRateOfTurn(tas, radius_nm) {
-  return tas / (111.95 * radius_nm);
+  // ω (°/s) = TAS (kt) / (r (NM) × 20π)  — exact derivation from ω=V/r with unit conversion
+  return tas / (20 * Math.PI * radius_nm);
 }
 
 /**
@@ -114,7 +115,7 @@ function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
   const rateOfTurn = calculateRateOfTurn(tas, radius);
   const rateOfTurnCapped = Math.min(rateOfTurn, 3);
   const radiusForCalc =
-    rateOfTurnCapped < rateOfTurn ? tas / (111.95 * rateOfTurnCapped) : radius;
+    rateOfTurnCapped < rateOfTurn ? tas / (20 * Math.PI * rateOfTurnCapped) : radius;
 
   return {
     radius,

--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -28,7 +28,7 @@ if (typeof calculateRadius === "undefined") {
 if (typeof calculateRateOfTurn === "undefined") {
   // eslint-disable-next-line no-unused-vars
   function calculateRateOfTurn(tas, radius_nm) {
-    return tas / (111.95 * radius_nm);
+    return tas / (20 * Math.PI * radius_nm);
   }
 }
 if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
@@ -41,7 +41,7 @@ if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
     var rateOfTurnCapped = Math.min(rateOfTurn, 3);
     var radiusForCalc =
       rateOfTurnCapped < rateOfTurn
-        ? tas / (111.95 * rateOfTurnCapped)
+        ? tas / (20 * Math.PI * rateOfTurnCapped)
         : radius;
     return {
       radius: radius,
@@ -62,6 +62,7 @@ function applyDisplayPrecision() {
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
   document.getElementById("outKFactor").textContent = fmt(_raw.kFactor);
   document.getElementById("outTas").textContent = fmt(_raw.tas);
+  document.getElementById("outRateOfTurn").textContent = fmt(_raw.rateOfTurn);
   document.getElementById("outR").textContent = fmt(_raw.r);
   document.getElementById("outL1").textContent = fmt(_raw.L1);
   document.getElementById("outL2").textContent = fmt(_raw.L2);
@@ -184,6 +185,7 @@ function calculateFlyby() {
   // --- Store raw results and render with current precision ---
   _raw.kFactor = kFactor;
   _raw.tas = tas;
+  _raw.rateOfTurn = radiusObj.rateOfTurnCapped;
   _raw.r = r;
   _raw.L1 = L1;
   _raw.L2 = L2;
@@ -671,8 +673,6 @@ function copyToWord() {
   const exact = document.getElementById("copyPrecision").value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
-  var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 60;
-
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
     "Altitude h1":
@@ -685,7 +685,7 @@ function copyToWord() {
     "Bank Angle": document.getElementById("bankAngle").value + "\u00b0",
     "Turn Angle A": document.getElementById("outTurnUsed").textContent,
     TAS: fmt(_raw.tas) + " KT",
-    "Rate of turn (R)": fmt(rateOfTurn) + " \u00b0/min",
+    "Rate of turn (R)": fmt(_raw.rateOfTurn) + " \u00b0/s",
     "Radius (r)": fmt(_raw.r) + " NM",
     "L1 = r x tan(A/2)": fmt(_raw.L1) + " NM",
     "L2 = 5 x V/3600": fmt(_raw.L2) + " NM",

--- a/html/js/flyover_calculation.js
+++ b/html/js/flyover_calculation.js
@@ -28,7 +28,7 @@ if (typeof calculateRadius === "undefined") {
 if (typeof calculateRateOfTurn === "undefined") {
   // eslint-disable-next-line no-unused-vars
   function calculateRateOfTurn(tas, radius_nm) {
-    return tas / (111.95 * radius_nm);
+    return tas / (20 * Math.PI * radius_nm);
   }
 }
 if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
@@ -41,7 +41,7 @@ if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
     var rateOfTurnCapped = Math.min(rateOfTurn, 3);
     var radiusForCalc =
       rateOfTurnCapped < rateOfTurn
-        ? tas / (111.95 * rateOfTurnCapped)
+        ? tas / (20 * Math.PI * rateOfTurnCapped)
         : radius;
     return {
       radius: radius,
@@ -153,6 +153,8 @@ function applyDisplayPrecision() {
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
   document.getElementById("outKFactor").textContent = fmt(_raw.kFactor);
   document.getElementById("outTas").textContent = fmt(_raw.tas);
+  document.getElementById("outRot1").textContent = fmt(_raw.rot1);
+  document.getElementById("outRot2").textContent = fmt(_raw.rot2);
   document.getElementById("outR1").textContent = fmt(_raw.r1);
   document.getElementById("outR2").textContent = fmt(_raw.r2);
   document.getElementById("outL1").textContent = fmt(_raw.L1);
@@ -234,6 +236,8 @@ function calculateFlyover() {
   // --- Store raw values ---
   _raw.kFactor = kFactor;
   _raw.tas = tas;
+  _raw.rot1 = r1Obj.rateOfTurnCapped;
+  _raw.rot2 = r2Obj.rateOfTurnCapped;
   _raw.r1 = r1;
   _raw.r2 = r2;
   _raw.L1 = L1;
@@ -642,9 +646,6 @@ function copyToWord() {
     document.getElementById("copyPrecision").dataset.value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
-  var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 60;
-  var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 60;
-
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
     "Altitude h1":
@@ -657,9 +658,9 @@ function copyToWord() {
     "Bank Angle r1": document.getElementById("bankAngle").value + "°",
     "Turn Angle (input)": document.getElementById("turnAngle").value + "°",
     TAS: fmt(_raw.tas) + " KT",
-    "R1": fmt(rateR1) + " °/min",
+    "R1 (rate of turn)": fmt(_raw.rot1) + " °/s",
     "Turn Angle Used": document.getElementById("outThetaEff").textContent,
-    "R2": fmt(rateR2) + " °/min",
+    "R2 (rate of turn)": fmt(_raw.rot2) + " °/s",
     "r1 (roll-in)": fmt(_raw.r1) + " NM",
     "r2 (roll-out, 15° fixed)": fmt(_raw.r2) + " NM",
     L1: fmt(_raw.L1) + " NM",

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -20,7 +20,7 @@ if (typeof calculateRadius === "undefined") {
 }
 if (typeof calculateRateOfTurn === "undefined") {
   var calculateRateOfTurn = function (tas, radius_nm) {
-    return tas / (111.95 * radius_nm);
+    return tas / (20 * Math.PI * radius_nm);
   };
 }
 if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
@@ -31,7 +31,7 @@ if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
     var rateOfTurnCapped = Math.min(rateOfTurn, 3);
     var radiusForCalc =
       rateOfTurnCapped < rateOfTurn
-        ? tas / (111.95 * rateOfTurnCapped)
+        ? tas / (20 * Math.PI * rateOfTurnCapped)
         : radius;
     return {
       radius: radius,
@@ -245,6 +245,7 @@ function computeFlyby(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
     type: "flyby",
     kFactor: kFactor,
     tas: tas,
+    rateOfTurn: rObj.rateOfTurnCapped,
     r: r,
     L1: L1,
     L2: L2,
@@ -279,6 +280,8 @@ function computeFlyover(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
     type: "flyover",
     kFactor: kFactor,
     tas: tas,
+    rot1: r1Obj.rateOfTurnCapped,
+    rot2: r2Obj.rateOfTurnCapped,
     r1: r1,
     r2: r2,
     arcPlusTrans: arcPlusTrans,
@@ -602,10 +605,13 @@ function copyToWord() {
     "WP1 TAS (KT)": fmt(_raw1.tas),
   };
   if (_raw1.type === "flyby") {
+    wp1Rows["WP1 Rate of Turn R (\u00B0/s)"] = fmt(_raw1.rateOfTurn);
     wp1Rows["WP1 Radius r (NM)"] = fmt(_raw1.r);
     wp1Rows["WP1 r\u00B7tan(A/2) (NM)"] = fmt(_raw1.L1);
     wp1Rows["WP1 5s\u00B7TAS/3600 (NM)"] = fmt(_raw1.L2);
   } else {
+    wp1Rows["WP1 R1 roll-in (\u00B0/s)"] = fmt(_raw1.rot1);
+    wp1Rows["WP1 R2 roll-out 15\u00B0 (\u00B0/s)"] = fmt(_raw1.rot2);
     wp1Rows["WP1 r\u2081 roll-in (NM)"] = fmt(_raw1.r1);
     wp1Rows["WP1 Arc+transition L1\u2013L4 (NM)"] = fmt(_raw1.arcPlusTrans);
     wp1Rows["WP1 L5 bank estab. (NM)"] = fmt(_raw1.bankEstab);
@@ -619,10 +625,13 @@ function copyToWord() {
     "WP2 TAS (KT)": fmt(_raw2.tas),
   };
   if (_raw2.type === "flyby") {
+    wp2Rows["WP2 Rate of Turn R (\u00B0/s)"] = fmt(_raw2.rateOfTurn);
     wp2Rows["WP2 Radius r (NM)"] = fmt(_raw2.r);
     wp2Rows["WP2 r\u00B7tan(B/2) (NM)"] = fmt(_raw2.L1);
     wp2Rows["WP2 5s\u00B7TAS/3600 (NM)"] = fmt(_raw2.L2);
   } else {
+    wp2Rows["WP2 R1 roll-in (\u00B0/s)"] = fmt(_raw2.rot1);
+    wp2Rows["WP2 R2 roll-out 15\u00B0 (\u00B0/s)"] = fmt(_raw2.rot2);
     wp2Rows["WP2 r\u2081 roll-in (NM)"] = fmt(_raw2.r1);
     wp2Rows["WP2 Arc+transition L1\u2013L4 (NM)"] = fmt(_raw2.arcPlusTrans);
     wp2Rows["WP2 L5 bank estab. (NM)"] = fmt(_raw2.bankEstab);


### PR DESCRIPTION
# fix(#80): correct rate-of-turn formula (111.95 → 20π) and add R output to all three calculators

## Context

Follow-up to PR #97 (issue #80). After merging, @antoniolocandro commented:
> "Doesn't seem correct for Flyby, probably check for Flyover. Also include in MSD combined"

Root cause: `calculateRateOfTurn` in `aviation-utils.js` used constant `111.95` instead of the
correct `20π ≈ 62.83`, derived from first principles:

```
ω (rad/s)  = V (m/s) / r (m)
           = TAS (kt) / (r (NM) × 3600)      [since 1 kt = 1 NM/hr]
ω (°/s)    = TAS / (r × 3600) × (180/π)
           = TAS / (r × 20π)                  ← correct constant
```

With `111.95`, the 3°/s PANS-OPS cap effectively fired at **~5.35°/s** instead of 3°/s
(`111.95 / 62.83 = 1.78 → 3 × 1.78 = 5.35`). For scenarios where the natural rate falls
between 3°/s and 5.35°/s — e.g. Flyover at TAS 136 kt / bank 25° (natural rate = 3.73°/s) —
the cap never triggered, producing a radius and all segment lengths that were too small.

Two additional issues were fixed in the same PR:
- Rate of turn was not displayed in the UI results section (only in Copy to Word)
- Rate of turn was shown in °/min; PANS-OPS defines the cap in °/s, so output now uses °/s
- MSD Combined had no rate of turn output at all

## Changes

### Phase 1 — Fix `calculateRateOfTurn` constant

| File | Change |
|---|---|
| `html/aviation-utils.js` | `111.95` → `20 * Math.PI` in `calculateRateOfTurn` and `calculateRadiusWithRateOfTurnCap` |
| `html/js/flyby_calculation.js` | Same fix in fallback stub |
| `html/js/flyover_calculation.js` | Same fix in fallback stub |
| `html/js/msd_calculation.js` | Same fix in fallback stub |

Concrete impact on the Flyover example from the review (TAS = 136.35 kt, bank = 25°):

| | Before (buggy) | After (correct) |
|---|---|---|
| Natural rate | 3.73°/s | 3.73°/s |
| Cap triggered? | ✗ No | ✓ Yes |
| r₁ used | 0.5810 NM | 0.7228 NM |
| MSD Total | 1.8116 NM | ~2.05 NM |

### Phase 2 — Rate of turn stored in `_raw` and shown in UI

**Flyby** (`html/js/flyby_calculation.js`, `html/Flyby_Calculation.html`):
- `calculateFlyby()` now stores `_raw.rateOfTurn = radiusObj.rateOfTurnCapped`
- `applyDisplayPrecision()` updates `#outRateOfTurn`
- New result card added to the intermediate-values grid (5 columns)
- `copyToWord()` uses `_raw.rateOfTurn` + `°/s` (removed the ad-hoc `(tas/r)×(180/π)/60` formula in °/min)

**Flyover** (`html/js/flyover_calculation.js`, `html/Flyover_Calculation.html`):
- `calculateFlyover()` stores `_raw.rot1` and `_raw.rot2`
- `applyDisplayPrecision()` updates `#outRot1` and `#outRot2`
- New rate-of-turn row with two cards added below the main intermediate-values grid
- `copyToWord()` uses stored values in °/s; keys renamed `"R1 (rate of turn)"` / `"R2 (rate of turn)"`

### Phase 3 — Rate of turn added to MSD Combined

`html/js/msd_calculation.js`:
- `computeFlyby()` return object now includes `rateOfTurn`
- `computeFlyover()` return object now includes `rot1` and `rot2`
- `copyToWord()` inserts rate of turn rows for both WP1 and WP2, for both Flyby and Flyover types

## Testing checklist

- [ ] Flyby TAS ≈ 130 kt, bank 25°: rate > 3°/s → cap fires, r enlarged, MSD changes vs old value
- [ ] Flyby TAS ≈ 234 kt, bank 25°: rate 2.18°/s < 3 → no cap, r unchanged, MSD unchanged
- [ ] Flyby UI: Rate of Turn card visible in results section, shows value in °/s
- [ ] Flyby Copy to Word: "Rate of turn (R)" row shows value in °/s (not °/min)
- [ ] Flyover TAS ≈ 136 kt, bank 25°: R1 = 3.73°/s → cap fires, r1 = 0.7228 NM (was 0.5810 NM)
- [ ] Flyover UI: R1 and R2 cards visible, both show values in °/s
- [ ] Flyover Copy to Word: "R1 (rate of turn)" and "R2 (rate of turn)" rows show °/s values
- [ ] MSD Combined (Flyby+Flyby): Copy to Word includes "WP1 Rate of Turn R (°/s)" and "WP2 Rate of Turn R (°/s)"
- [ ] MSD Combined (Flyover+Flyover): Copy to Word includes R1/R2 rows for both WPs
- [ ] MSD Combined (mixed Flyby+Flyover): Copy to Word shows correct rows per WP type
- [ ] Rate of turn ≤ 3.0000 °/s whenever cap is applied (verifiable by checking displayed value)
