### PR TITLE
Issue #84 follow-up: MSD sidebar fills available space, wider on large screens

### DIFF
--- a/html/MSD_Calculation.html
+++ b/html/MSD_Calculation.html
@@ -20,6 +20,12 @@
     <link rel="stylesheet" href="dark-mode.css" />
     <script src="aviation-utils.js"></script>
     <script src="i18n/i18n.js"></script>
+  <style>
+    @media (min-width: 1024px) {
+      #caseRefSidebar { transition: width 0.3s ease, opacity 0.2s ease; }
+      #caseRefSidebar.sidebar-collapsed { width: 0 !important; overflow: hidden; opacity: 0; }
+    }
+  </style>
   </head>
   <body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
     <div class="flex flex-col lg:flex-row items-start lg:justify-center gap-6 w-full max-w-6xl mx-auto pt-8 px-4 pb-12">
@@ -1065,10 +1071,23 @@
     </main>
 
     <!-- Case Reference Sidebar -->
-    <aside class="w-full lg:w-96 shrink-0 lg:sticky lg:top-8">
-      <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500 mb-2 lg:text-right">
-        Case Reference
-      </p>
+    <aside id="caseRefSidebar" class="w-full lg:w-96 shrink-0 lg:sticky lg:top-8">
+      <div class="flex items-center justify-between mb-2">
+        <button
+          id="sidebarCollapseBtn"
+          class="hidden lg:flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.18em] text-primary-400 bg-gray-900/70 dark:bg-gray-950/80 backdrop-blur-sm border border-primary-500/25 rounded-full pl-2.5 pr-3 py-1.5 shadow-sm hover:text-primary-300 hover:border-primary-400/45 hover:bg-gray-800/90 hover:shadow-[0_2px_12px_rgba(14,165,233,0.15)] transition-all duration-200 shrink-0"
+          title="Hide case reference"
+          aria-label="Hide case reference"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-3 h-3 shrink-0 opacity-80">
+            <path fill-rule="evenodd" d="M9.78 4.22a.75.75 0 0 1 0 1.06L7.06 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L5.47 8.53a.75.75 0 0 1 0-1.06l3.25-3.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+          </svg>
+          Hide
+        </button>
+        <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+          Case Reference
+        </p>
+      </div>
       <figure
         id="caseDiagramSection"
         class="rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 shadow-sm"
@@ -1099,6 +1118,46 @@
     </aside>
     </div><!-- /layout wrapper -->
 
+    <!-- Floating button to reopen sidebar after collapse (desktop only) -->
+    <button
+      id="sidebarExpandBtn"
+      style="display:none"
+      class="fixed right-4 top-20 z-50 flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.18em] text-primary-400 bg-gray-900/80 dark:bg-gray-950/85 backdrop-blur-md border border-primary-500/25 rounded-full pl-3.5 pr-4 py-2.5 shadow-[0_4px_24px_rgba(0,0,0,0.35)] hover:text-primary-300 hover:border-primary-400/50 hover:bg-gray-800/90 hover:shadow-[0_6px_28px_rgba(14,165,233,0.18)] transition-all duration-200"
+      title="Show case reference"
+      aria-label="Show case reference"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-3.5 h-3.5 shrink-0 opacity-80">
+        <path fill-rule="evenodd" d="M6.22 4.22a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06L7.28 11.78a.75.75 0 0 1-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+      </svg>
+      Case Ref
+    </button>
+
     <script src="js/msd_calculation.js"></script>
+    <script>
+      (function () {
+        var sidebar = document.getElementById("caseRefSidebar");
+        var collapseBtn = document.getElementById("sidebarCollapseBtn");
+        var expandBtn = document.getElementById("sidebarExpandBtn");
+
+        function collapse() {
+          sidebar.classList.add("sidebar-collapsed");
+          expandBtn.style.display = "flex";
+          setTimeout(function () { sidebar.classList.add("hidden"); }, 300);
+        }
+
+        function expand() {
+          sidebar.classList.remove("hidden");
+          requestAnimationFrame(function () {
+            requestAnimationFrame(function () {
+              sidebar.classList.remove("sidebar-collapsed");
+            });
+          });
+          expandBtn.style.display = "none";
+        }
+
+        collapseBtn.addEventListener("click", collapse);
+        expandBtn.addEventListener("click", expand);
+      })();
+    </script>
   </body>
 </html>

--- a/html/MSD_Calculation.html
+++ b/html/MSD_Calculation.html
@@ -813,7 +813,7 @@
                 class="text-xs font-bold px-2 py-0.5 rounded-full bg-amber-200 dark:bg-amber-800 text-amber-800 dark:text-amber-200"
               ></span>
             </div>
-            <div class="grid grid-cols-2 gap-2 text-sm">
+            <div id="out2Grid" class="grid grid-cols-2 gap-2 text-sm">
               <div
                 class="bg-white dark:bg-gray-800 rounded-lg p-2.5 border border-amber-100 dark:border-amber-900"
               >
@@ -1065,7 +1065,7 @@
     </main>
 
     <!-- Case Reference Sidebar -->
-    <aside class="w-full lg:w-64 shrink-0 lg:sticky lg:top-8">
+    <aside class="w-full lg:w-96 shrink-0 lg:sticky lg:top-8">
       <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500 mb-2 lg:text-right">
         Case Reference
       </p>

--- a/html/MSD_Calculation.html
+++ b/html/MSD_Calculation.html
@@ -1071,7 +1071,7 @@
     </main>
 
     <!-- Case Reference Sidebar -->
-    <aside id="caseRefSidebar" class="w-full lg:w-[400px] xl:w-[460px] shrink-0 lg:sticky lg:top-8">
+    <aside id="caseRefSidebar" class="w-full lg:w-[400px] xl:w-[460px] 2xl:w-[560px] lg:grow shrink-0 lg:sticky lg:top-8">
       <div class="flex items-center justify-between mb-2">
         <button
           id="sidebarCollapseBtn"

--- a/html/MSD_Calculation.html
+++ b/html/MSD_Calculation.html
@@ -28,9 +28,9 @@
   </style>
   </head>
   <body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
-    <div class="flex flex-col lg:flex-row items-start lg:justify-center gap-6 w-full max-w-6xl mx-auto pt-8 px-4 pb-12">
+    <div class="flex flex-col lg:flex-row items-start gap-6 w-full max-w-[1600px] mx-auto pt-8 px-4 pb-12">
     <main
-      class="max-w-4xl w-full p-6 bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700"
+      class="max-w-4xl w-full mx-auto p-6 bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700"
     >
       <header>
         <h1
@@ -1071,7 +1071,7 @@
     </main>
 
     <!-- Case Reference Sidebar -->
-    <aside id="caseRefSidebar" class="w-full lg:w-96 shrink-0 lg:sticky lg:top-8">
+    <aside id="caseRefSidebar" class="w-full lg:w-[400px] xl:w-[460px] shrink-0 lg:sticky lg:top-8">
       <div class="flex items-center justify-between mb-2">
         <button
           id="sidebarCollapseBtn"

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -71,18 +71,23 @@ function applyDisplayPrecision() {
   document.getElementById("out1M").textContent = fmt(_raw1.M);
 
   // WP2
-  document.getElementById("out2KFactor").textContent = fmt(_raw2.kFactor);
-  document.getElementById("out2Tas").textContent = fmt(_raw2.tas);
-  if (_raw2.type === "flyby") {
-    document.getElementById("out2Radius").textContent = fmt(_raw2.r);
-    document.getElementById("out2L1").textContent = fmt(_raw2.L1);
-    document.getElementById("out2L2").textContent = fmt(_raw2.L2);
+  if (_raw2.kFactor === 0) {
+    // WP2 flyover zero case — only show M₂=0
+    document.getElementById("out2M").textContent = fmt(0);
   } else {
-    document.getElementById("out2Radius").textContent = fmt(_raw2.r1);
-    document.getElementById("out2L1").textContent = fmt(_raw2.arcPlusTrans);
-    document.getElementById("out2L2").textContent = fmt(_raw2.bankEstab);
+    document.getElementById("out2KFactor").textContent = fmt(_raw2.kFactor);
+    document.getElementById("out2Tas").textContent = fmt(_raw2.tas);
+    if (_raw2.type === "flyby") {
+      document.getElementById("out2Radius").textContent = fmt(_raw2.r);
+      document.getElementById("out2L1").textContent = fmt(_raw2.L1);
+      document.getElementById("out2L2").textContent = fmt(_raw2.L2);
+    } else {
+      document.getElementById("out2Radius").textContent = fmt(_raw2.r1);
+      document.getElementById("out2L1").textContent = fmt(_raw2.arcPlusTrans);
+      document.getElementById("out2L2").textContent = fmt(_raw2.bankEstab);
+    }
+    document.getElementById("out2M").textContent = fmt(_raw2.M);
   }
-  document.getElementById("out2M").textContent = fmt(_raw2.M);
 
   // MSD total
   var msd = _raw1.M + _raw2.M;
@@ -290,6 +295,8 @@ function computeFlyover(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
 // ── Main calculation ──────────────────────────────────────────────────────────
 
 function calculateMSD() {
+  updateCaseDiagram();
+
   // Read shared inputs
   var distanceD = parseFloat(document.getElementById("distance").value);
   var isaRaw = document.getElementById("isaDeviation").value.trim();
@@ -308,6 +315,8 @@ function calculateMSD() {
 
   // Read WP2 inputs
   var wp2Type = document.getElementById("wp2Type").value;
+  // WP2 only contributes M₂ when it is a Flyby (PANS-OPS §1.4.2 cases 2, 3, 4)
+  var wp2Active = wp2Type === "flyby";
   var wp2Ias = parseFloat(document.getElementById("wp2Ias").value);
   var wp2AltRaw = parseFloat(document.getElementById("wp2Altitude").value);
   var wp2AltUnit = document.getElementById("wp2AltitudeUnit").value;
@@ -344,37 +353,38 @@ function calculateMSD() {
     showToast("WP1: Turn angle must be at least 50°.", "error");
     return;
   }
-  if (isNaN(wp2Ias) || wp2Ias <= 0) {
-    showToast("WP2: Please enter a valid IAS.", "error");
-    return;
-  }
-  if (isNaN(wp2AltRaw) || wp2AltRaw < 0) {
-    showToast("WP2: Please enter a valid altitude.", "error");
-    return;
-  }
-  if (isNaN(wp2Bank) || wp2Bank <= 0 || wp2Bank >= 90) {
-    showToast("WP2: Bank angle must be between 1° and 89°.", "error");
-    return;
-  }
-  if (isNaN(wp2Turn) || wp2Turn < 50 || wp2Turn >= 360) {
-    showToast("WP2: Turn angle must be at least 50°.", "error");
-    return;
+  if (wp2Active) {
+    if (isNaN(wp2Ias) || wp2Ias <= 0) {
+      showToast("WP2: Please enter a valid IAS.", "error");
+      return;
+    }
+    if (isNaN(wp2AltRaw) || wp2AltRaw < 0) {
+      showToast("WP2: Please enter a valid altitude.", "error");
+      return;
+    }
+    if (isNaN(wp2Bank) || wp2Bank <= 0 || wp2Bank >= 90) {
+      showToast("WP2: Bank angle must be between 1° and 89°.", "error");
+      return;
+    }
+    if (isNaN(wp2Turn) || wp2Turn < 50 || wp2Turn >= 360) {
+      showToast("WP2: Turn angle must be at least 50°.", "error");
+      return;
+    }
   }
 
   // Convert altitudes to ft
   var wp1Alt_ft = wp1AltUnit === "m" ? wp1AltRaw / 0.3048 : wp1AltRaw;
-  var wp2Alt_ft = wp2AltUnit === "m" ? wp2AltRaw / 0.3048 : wp2AltRaw;
+  var wp2Alt_ft = wp2Active ? (wp2AltUnit === "m" ? wp2AltRaw / 0.3048 : wp2AltRaw) : 0;
 
-  // Compute per WP
+  // Compute per WP — WP2 flyover cases use M₂=0 per PANS-OPS §1.4.2
   var res1 =
     wp1Type === "flyby"
       ? computeFlyby(wp1Ias, wp1Alt_ft, wp1Bank, wp1Turn, isaDeviation)
       : computeFlyover(wp1Ias, wp1Alt_ft, wp1Bank, wp1Turn, isaDeviation);
 
-  var res2 =
-    wp2Type === "flyby"
-      ? computeFlyby(wp2Ias, wp2Alt_ft, wp2Bank, wp2Turn, isaDeviation)
-      : computeFlyover(wp2Ias, wp2Alt_ft, wp2Bank, wp2Turn, isaDeviation);
+  var res2 = wp2Active
+    ? computeFlyby(wp2Ias, wp2Alt_ft, wp2Bank, wp2Turn, isaDeviation)
+    : { type: "flyover", M: 0, kFactor: 0, tas: 0 };
 
   // Store
   _raw1 = res1;
@@ -479,6 +489,17 @@ function renderWPResults(n, result, name) {
   var radiusLabel = document.getElementById(prefix + "RadiusLabel");
   var l1Label = document.getElementById(prefix + "L1Label");
   var l2Label = document.getElementById(prefix + "L2Label");
+
+  // WP2 flyover zero case — hide intermediate grid, show only M₂=0
+  if (n === 2 && result.kFactor === 0) {
+    typeBadge.textContent = "Flyover";
+    document.getElementById("out2Grid").classList.add("hidden");
+    return;
+  }
+
+  if (n === 2) {
+    document.getElementById("out2Grid").classList.remove("hidden");
+  }
 
   if (result.type === "flyby") {
     typeBadge.textContent = "Flyby";
@@ -612,22 +633,28 @@ function copyToWord() {
   }
   wp1Rows["M\u2081 (NM)"] = fmt(_raw1.M);
 
-  // Build WP2 rows
-  var wp2Rows = {
-    "WP2 Type": _raw2.type.charAt(0).toUpperCase() + _raw2.type.slice(1),
-    "WP2 k Factor": fmt(_raw2.kFactor),
-    "WP2 TAS (KT)": fmt(_raw2.tas),
-  };
-  if (_raw2.type === "flyby") {
-    wp2Rows["WP2 Radius r (NM)"] = fmt(_raw2.r);
-    wp2Rows["WP2 r\u00B7tan(B/2) (NM)"] = fmt(_raw2.L1);
-    wp2Rows["WP2 5s\u00B7TAS/3600 (NM)"] = fmt(_raw2.L2);
+  // Build WP2 rows — flyover zero case omits intermediate values
+  var wp2Rows;
+  if (_raw2.kFactor === 0) {
+    wp2Rows = { "WP2 Type": "Flyover (M₂ = 0)" };
+    wp2Rows["M₂ (NM)"] = fmt(0);
   } else {
-    wp2Rows["WP2 r\u2081 roll-in (NM)"] = fmt(_raw2.r1);
-    wp2Rows["WP2 Arc+transition L1\u2013L4 (NM)"] = fmt(_raw2.arcPlusTrans);
-    wp2Rows["WP2 L5 bank estab. (NM)"] = fmt(_raw2.bankEstab);
+    wp2Rows = {
+      "WP2 Type": _raw2.type.charAt(0).toUpperCase() + _raw2.type.slice(1),
+      "WP2 k Factor": fmt(_raw2.kFactor),
+      "WP2 TAS (KT)": fmt(_raw2.tas),
+    };
+    if (_raw2.type === "flyby") {
+      wp2Rows["WP2 Radius r (NM)"] = fmt(_raw2.r);
+      wp2Rows["WP2 r\u00B7tan(B/2) (NM)"] = fmt(_raw2.L1);
+      wp2Rows["WP2 5s\u00B7TAS/3600 (NM)"] = fmt(_raw2.L2);
+    } else {
+      wp2Rows["WP2 r\u2081 roll-in (NM)"] = fmt(_raw2.r1);
+      wp2Rows["WP2 Arc+transition L1\u2013L4 (NM)"] = fmt(_raw2.arcPlusTrans);
+      wp2Rows["WP2 L5 bank estab. (NM)"] = fmt(_raw2.bankEstab);
+    }
+    wp2Rows["M\u2082 (NM)"] = fmt(_raw2.M);
   }
-  wp2Rows["M\u2082 (NM)"] = fmt(_raw2.M);
 
   // Combined rows
   var msd = _raw1.M + _raw2.M;

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -623,10 +623,13 @@ function copyToWord() {
     "WP1 TAS (KT)": fmt(_raw1.tas),
   };
   if (_raw1.type === "flyby") {
+    wp1Rows["WP1 Rate of Turn R (\u00B0/s)"] = fmt(_raw1.rateOfTurn);
     wp1Rows["WP1 Radius r (NM)"] = fmt(_raw1.r);
     wp1Rows["WP1 r\u00B7tan(A/2) (NM)"] = fmt(_raw1.L1);
     wp1Rows["WP1 5s\u00B7TAS/3600 (NM)"] = fmt(_raw1.L2);
   } else {
+    wp1Rows["WP1 R1 roll-in (\u00B0/s)"] = fmt(_raw1.rot1);
+    wp1Rows["WP1 R2 roll-out 15\u00B0 (\u00B0/s)"] = fmt(_raw1.rot2);
     wp1Rows["WP1 r\u2081 roll-in (NM)"] = fmt(_raw1.r1);
     wp1Rows["WP1 Arc+transition L1\u2013L4 (NM)"] = fmt(_raw1.arcPlusTrans);
     wp1Rows["WP1 L5 bank estab. (NM)"] = fmt(_raw1.bankEstab);
@@ -645,10 +648,13 @@ function copyToWord() {
       "WP2 TAS (KT)": fmt(_raw2.tas),
     };
     if (_raw2.type === "flyby") {
+      wp2Rows["WP2 Rate of Turn R (\u00B0/s)"] = fmt(_raw2.rateOfTurn);
       wp2Rows["WP2 Radius r (NM)"] = fmt(_raw2.r);
       wp2Rows["WP2 r\u00B7tan(B/2) (NM)"] = fmt(_raw2.L1);
       wp2Rows["WP2 5s\u00B7TAS/3600 (NM)"] = fmt(_raw2.L2);
     } else {
+      wp2Rows["WP2 R1 roll-in (\u00B0/s)"] = fmt(_raw2.rot1);
+      wp2Rows["WP2 R2 roll-out 15\u00B0 (\u00B0/s)"] = fmt(_raw2.rot2);
       wp2Rows["WP2 r\u2081 roll-in (NM)"] = fmt(_raw2.r1);
       wp2Rows["WP2 Arc+transition L1\u2013L4 (NM)"] = fmt(_raw2.arcPlusTrans);
       wp2Rows["WP2 L5 bank estab. (NM)"] = fmt(_raw2.bankEstab);


### PR DESCRIPTION
# PR — Issue #84 follow-up: MSD sidebar fills available space, wider on large screens`

## Context

Follow-up on the case reference sidebar layout in the MSD Combined Calculator. The sidebar had a fixed width (`lg:w-[400px] xl:w-[460px]`) which left unused dark space to the right of the sidebar on wide screens. Two improvements are applied:

1. **Sidebar grows to fill remaining space**: `lg:grow` makes the sidebar absorb all horizontal space left over after the MSD card's `max-w-4xl` (896px). No more dark right margin regardless of viewport width.
2. **Wider baseline on 2xl screens**: `2xl:w-[560px]` raises the minimum sidebar width from 460px to 560px on screens ≥1536px, so the case reference diagram renders larger by default before any growth.
<img width="1920" height="1078" alt="{F435138F-83FE-424D-A012-207F2E029392}" src="https://github.com/user-attachments/assets/0407bde1-5acb-4268-9615-1a8dc16e7bf4" />

## Changes

### `html/MSD_Calculation.html`

| Before | After |
|---|---|
| `class="w-full lg:w-[400px] xl:w-[460px] shrink-0 lg:sticky lg:top-8"` | `class="w-full lg:w-[400px] xl:w-[460px] 2xl:w-[560px] lg:grow shrink-0 lg:sticky lg:top-8"` |

## Behaviour per breakpoint

| Breakpoint | Sidebar starts at | Grows to |
|---|---|---|
| `< lg` (mobile) | `w-full` (full width, stacked) | — |
| `lg` (1024–1279px) | 400px | fills remaining space after 896px MSD card |
| `xl` (1280–1535px) | 460px | fills remaining space |
| `2xl` (1536px+) | 560px | fills remaining space (~640–680px at 1920px) |

The MSD card keeps its `max-w-4xl` (896px) and `shrink-0` sidebar ensures the sidebar never compresses below its stated minimum width.

## Testing checklist

- [ ] 1920px screen: no dark space to the right of the case reference sidebar
- [ ] 1440px screen: sidebar wider than before, no right gap
- [ ] 1280px screen: sidebar at 460px minimum, no overflow
- [ ] Collapse/expand sidebar animation still works correctly
- [ ] Mobile (< 1024px): sidebar stacks below MSD form, full width, no regression
