### PR TITLE
fix(#86 follow-up): Use 50° minimum without blocking; optional override checkbox

### DIFF
--- a/html/MSD_Calculation.html
+++ b/html/MSD_Calculation.html
@@ -363,7 +363,7 @@
                       id="wp1TurnAngle"
                       name="wp1TurnAngle"
                       type="number"
-                      min="50"
+                      min="1"
                       max="359"
                       step="0.1"
                       inputmode="decimal"
@@ -410,13 +410,25 @@
                   <line x1="12" y1="9" x2="12" y2="13"></line>
                   <line x1="12" y1="17" x2="12.01" y2="17"></line>
                 </svg>
-                <p
-                  class="text-xs text-amber-700 dark:text-amber-300"
-                  data-i18n="msd.turnAngleWarning"
-                >
-                  Input &lt; 50&#176; &#8212; minimum 50&#176; applied (Flyby
-                  only)
-                </p>
+                <div>
+                  <p
+                    class="text-xs text-amber-700 dark:text-amber-300"
+                    data-i18n="msd.turnAngleWarning"
+                  >
+                    Input &lt; 50&#176; &#8212; minimum 50&#176; applied (Flyby
+                    only)
+                  </p>
+                  <label class="flex items-center gap-1.5 mt-1.5 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      id="wp1TurnOverride"
+                      class="accent-amber-600 h-3.5 w-3.5"
+                    />
+                    <span class="text-xs text-amber-700 dark:text-amber-300"
+                      >Override 50&#176; requirement and use exact turn angle</span
+                    >
+                  </label>
+                </div>
               </div>
             </div>
 
@@ -589,7 +601,7 @@
                       id="wp2TurnAngle"
                       name="wp2TurnAngle"
                       type="number"
-                      min="50"
+                      min="1"
                       max="359"
                       step="0.1"
                       inputmode="decimal"
@@ -636,13 +648,25 @@
                   <line x1="12" y1="9" x2="12" y2="13"></line>
                   <line x1="12" y1="17" x2="12.01" y2="17"></line>
                 </svg>
-                <p
-                  class="text-xs text-amber-700 dark:text-amber-300"
-                  data-i18n="msd.turnAngleWarning"
-                >
-                  Input &lt; 50&#176; &#8212; minimum 50&#176; applied (Flyby
-                  only)
-                </p>
+                <div>
+                  <p
+                    class="text-xs text-amber-700 dark:text-amber-300"
+                    data-i18n="msd.turnAngleWarning"
+                  >
+                    Input &lt; 50&#176; &#8212; minimum 50&#176; applied (Flyby
+                    only)
+                  </p>
+                  <label class="flex items-center gap-1.5 mt-1.5 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      id="wp2TurnOverride"
+                      class="accent-amber-600 h-3.5 w-3.5"
+                    />
+                    <span class="text-xs text-amber-700 dark:text-amber-300"
+                      >Override 50&#176; requirement and use exact turn angle</span
+                    >
+                  </label>
+                </div>
               </div>
             </div>
           </div>
@@ -708,6 +732,10 @@
                 class="text-xs font-bold px-2 py-0.5 rounded-full bg-blue-200 dark:bg-blue-800 text-blue-800 dark:text-blue-200"
               ></span>
             </div>
+            <p
+              id="out1MinAppliedNote"
+              class="hidden text-xs text-amber-600 dark:text-amber-400 mb-2"
+            ></p>
             <div class="grid grid-cols-2 gap-2 text-sm">
               <div
                 class="bg-white dark:bg-gray-800 rounded-lg p-2.5 border border-blue-100 dark:border-blue-900"
@@ -815,6 +843,10 @@
                 class="text-xs font-bold px-2 py-0.5 rounded-full bg-amber-200 dark:bg-amber-800 text-amber-800 dark:text-amber-200"
               ></span>
             </div>
+            <p
+              id="out2MinAppliedNote"
+              class="hidden text-xs text-amber-600 dark:text-amber-400 mb-2"
+            ></p>
             <div class="grid grid-cols-2 gap-2 text-sm">
               <div
                 class="bg-white dark:bg-gray-800 rounded-lg p-2.5 border border-amber-100 dark:border-amber-900"

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -173,6 +173,8 @@ function setupEventListeners() {
     document
       .getElementById(prefix + "Type")
       .addEventListener("change", function () {
+        // Reset override when type changes — override only applies to flyby
+        document.getElementById(prefix + "TurnOverride").checked = false;
         // Re-check warning when type changes
         var angleEl = document.getElementById(prefix + "TurnAngle");
         angleEl.dispatchEvent(new Event("input"));
@@ -230,14 +232,14 @@ function handleUnitChange(inputId, unitSelectId) {
 
 // ── Aviation formulas ─────────────────────────────────────────────────────────
 
-function computeFlyby(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
+function computeFlyby(ias, altitude_ft, bankAngle, turnAngle, isaDeviation, override) {
   var DEG_TO_RAD = Math.PI / 180;
   var kFactor = calculateKFactor(altitude_ft, isaDeviation);
   var tas = calculateTAS(ias, kFactor);
   var rObj = calculateRadiusWithRateOfTurnCap(tas, bankAngle);
   var r = rObj.radiusForCalc;
-  var effectiveTurn = Math.max(turnAngle, 50);
-  var minApplied = effectiveTurn !== turnAngle;
+  var effectiveTurn = override ? turnAngle : Math.max(turnAngle, 50);
+  var minApplied = !override && effectiveTurn !== turnAngle;
   var L1 = r * Math.tan((effectiveTurn / 2) * DEG_TO_RAD);
   var L2 = (5 * tas) / 3600;
   var M = L1 + L2;
@@ -250,6 +252,7 @@ function computeFlyby(ias, altitude_ft, bankAngle, turnAngle, isaDeviation) {
     L1: L1,
     L2: L2,
     M: M,
+    inputTurn: turnAngle,
     effectiveTurn: effectiveTurn,
     minApplied: minApplied,
   };
@@ -343,8 +346,8 @@ function calculateMSD() {
     showToast("WP1: Bank angle must be between 1° and 89°.", "error");
     return;
   }
-  if (isNaN(wp1Turn) || wp1Turn < 50 || wp1Turn >= 360) {
-    showToast("WP1: Turn angle must be at least 50°.", "error");
+  if (isNaN(wp1Turn) || wp1Turn <= 0 || wp1Turn >= 360) {
+    showToast("WP1: Enter a turn angle between 1° and 359°.", "error");
     return;
   }
   if (isNaN(wp2Ias) || wp2Ias <= 0) {
@@ -359,8 +362,8 @@ function calculateMSD() {
     showToast("WP2: Bank angle must be between 1° and 89°.", "error");
     return;
   }
-  if (isNaN(wp2Turn) || wp2Turn < 50 || wp2Turn >= 360) {
-    showToast("WP2: Turn angle must be at least 50°.", "error");
+  if (isNaN(wp2Turn) || wp2Turn <= 0 || wp2Turn >= 360) {
+    showToast("WP2: Enter a turn angle between 1° and 359°.", "error");
     return;
   }
 
@@ -368,15 +371,21 @@ function calculateMSD() {
   var wp1Alt_ft = wp1AltUnit === "m" ? wp1AltRaw / 0.3048 : wp1AltRaw;
   var wp2Alt_ft = wp2AltUnit === "m" ? wp2AltRaw / 0.3048 : wp2AltRaw;
 
+  // Read override checkboxes (only relevant for flyby when angle < 50°)
+  var wp1Override = wp1Type === "flyby" &&
+    document.getElementById("wp1TurnOverride").checked;
+  var wp2Override = wp2Type === "flyby" &&
+    document.getElementById("wp2TurnOverride").checked;
+
   // Compute per WP
   var res1 =
     wp1Type === "flyby"
-      ? computeFlyby(wp1Ias, wp1Alt_ft, wp1Bank, wp1Turn, isaDeviation)
+      ? computeFlyby(wp1Ias, wp1Alt_ft, wp1Bank, wp1Turn, isaDeviation, wp1Override)
       : computeFlyover(wp1Ias, wp1Alt_ft, wp1Bank, wp1Turn, isaDeviation);
 
   var res2 =
     wp2Type === "flyby"
-      ? computeFlyby(wp2Ias, wp2Alt_ft, wp2Bank, wp2Turn, isaDeviation)
+      ? computeFlyby(wp2Ias, wp2Alt_ft, wp2Bank, wp2Turn, isaDeviation, wp2Override)
       : computeFlyover(wp2Ias, wp2Alt_ft, wp2Bank, wp2Turn, isaDeviation);
 
   // Store
@@ -495,6 +504,16 @@ function renderWPResults(n, result, name) {
     l2Label.textContent = "L5 (bank estab.)";
   }
 
+  var minNote = document.getElementById(prefix + "MinAppliedNote");
+  if (result.type === "flyby" && result.minApplied) {
+    minNote.textContent =
+      "\u26A0\uFE0F 50\u00B0 minimum applied \u2014 entered " +
+      result.inputTurn.toFixed(1) + "\u00B0, using 50\u00B0";
+    minNote.classList.remove("hidden");
+  } else {
+    minNote.classList.add("hidden");
+  }
+
   document.getElementById(prefix + "L1Cell").classList.remove("hidden");
   document.getElementById(prefix + "L2Cell").classList.remove("hidden");
   document.getElementById(prefix + "L2Cell").classList.remove("col-span-2");
@@ -605,6 +624,10 @@ function copyToWord() {
     "WP1 TAS (KT)": fmt(_raw1.tas),
   };
   if (_raw1.type === "flyby") {
+    if (_raw1.minApplied) {
+      wp1Rows["WP1 Turn Angle entered (\u00B0)"] = fmt(_raw1.inputTurn);
+      wp1Rows["WP1 Effective Turn \u2265 50\u00B0 (\u00B0)"] = fmt(_raw1.effectiveTurn) + " (50\u00B0 min applied)";
+    }
     wp1Rows["WP1 Rate of Turn R (\u00B0/s)"] = fmt(_raw1.rateOfTurn);
     wp1Rows["WP1 Radius r (NM)"] = fmt(_raw1.r);
     wp1Rows["WP1 r\u00B7tan(A/2) (NM)"] = fmt(_raw1.L1);
@@ -625,6 +648,10 @@ function copyToWord() {
     "WP2 TAS (KT)": fmt(_raw2.tas),
   };
   if (_raw2.type === "flyby") {
+    if (_raw2.minApplied) {
+      wp2Rows["WP2 Turn Angle entered (\u00B0)"] = fmt(_raw2.inputTurn);
+      wp2Rows["WP2 Effective Turn \u2265 50\u00B0 (\u00B0)"] = fmt(_raw2.effectiveTurn) + " (50\u00B0 min applied)";
+    }
     wp2Rows["WP2 Rate of Turn R (\u00B0/s)"] = fmt(_raw2.rateOfTurn);
     wp2Rows["WP2 Radius r (NM)"] = fmt(_raw2.r);
     wp2Rows["WP2 r\u00B7tan(B/2) (NM)"] = fmt(_raw2.L1);


### PR DESCRIPTION
# fix(#86 follow-up): Use 50° minimum without blocking; optional override checkbox
<img width="407" height="551" alt="{88A7FE07-510E-43BD-865F-CC070AF4288B}" src="https://github.com/user-attachments/assets/dd23271d-ac14-4237-93f7-77f0a9489ded" />

<img width="402" height="569" alt="{1DBB5795-D0A7-47B6-8CE1-05A0A99B8B81}" src="https://github.com/user-attachments/assets/20eee8f8-78f8-4a4c-a87a-2a53e4a28d69" />

## Root Cause

The `computeFlyby()` function already had `effectiveTurn = Math.max(turnAngle, 50)` and tracked
`minApplied`. The only blocker was the validation guard (`wp1Turn < 50`) in `calculate()` that
returned before reaching `computeFlyby`.

---

## Changes

### `html/MSD_Calculation.html`

| Element | Change |
|---|---|
| `#wp1TurnAngle` `min` | `50` → `1` (removes browser-native blocking) |
| `#wp2TurnAngle` `min` | `50` → `1` |
| `#wp1TurnWarning` badge | Added override checkbox `#wp1TurnOverride` inside the badge |
| `#wp2TurnWarning` badge | Added override checkbox `#wp2TurnOverride` inside the badge |
| `#out1MinAppliedNote` | New `<p>` element after WP1 results header (hidden by default) |
| `#out2MinAppliedNote` | New `<p>` element after WP2 results header (hidden by default) |

The override checkbox is inside the amber warning badge, so it appears and disappears
automatically with the badge (no extra show/hide logic needed).

### `html/js/msd_calculation.js`

**`calculate()` — validation**

| Before | After |
|---|---|
| `wp1Turn < 50` blocks with "must be at least 50°" | `wp1Turn <= 0` blocks with "between 1° and 359°" |
| `wp2Turn < 50` blocks with "must be at least 50°" | `wp2Turn <= 0` blocks with "between 1° and 359°" |

**`calculate()` — override flag**

Reads `#wp1TurnOverride.checked` / `#wp2TurnOverride.checked` (only when type is flyby) and
passes the flag to `computeFlyby`.

**`computeFlyby()`**

Added `override` parameter (6th arg):
- When `override = true`: `effectiveTurn = turnAngle` (exact angle used, `minApplied = false`)
- When `override = false`: `effectiveTurn = Math.max(turnAngle, 50)` (existing behaviour)
- Added `inputTurn: turnAngle` to the returned result object.

**`renderWPResults()`**

Shows `#outNMinAppliedNote` when `result.minApplied`:
> ⚠️ 50° minimum applied — entered 30.0°, using 50°

Hides the note otherwise.

**Type-change listener**

Resets override checkbox to unchecked when WP type changes (override only applies to flyby).

**`copyToWord()`**

When `_rawN.minApplied`, two extra rows are inserted before the Rate of Turn row:
```
WP1 Turn Angle entered (°) | 30.00
WP1 Effective Turn ≥ 50° (°) | 50.00  (50° min applied)
```

---

## Behaviour summary

| Scenario | Result |
|---|---|
| Flyby, turn = 80° | Normal calculation, no badge, no note |
| Flyby, turn = 30°, override unchecked | Calculates with 50°; badge + note shown; Word shows entered/effective rows |
| Flyby, turn = 30°, override checked | Calculates with exact 30°; no note in results; no extra Word rows |
| Flyover, any turn | Badge never shown; turn used as-is (no 50° rule for flyover) |
| Type changes to flyover | Override checkbox reset to unchecked |

---

## Testing checklist

- [ ] WP1 flyby, turn = 30° → calculation proceeds, results show "⚠️ 50° minimum applied — entered 30.0°, using 50°"
- [ ] WP1 flyby, turn = 30°, check override → results show no note, M uses 30°
- [ ] WP1 flyby, turn = 80° → no badge, no note
- [ ] Change WP1 type flyby → flyover → override checkbox disappears with badge and is reset
- [ ] Both WPs flyby, both < 50° → each shows its own badge + note independently
- [ ] Copy to Word with turn = 30° (no override) → table includes "Turn Angle entered" and "Effective Turn ≥ 50°" rows
- [ ] Copy to Word with turn = 30° + override checked → no extra rows
- [ ] Copy to Word with turn = 80° → no extra rows

---

## Files Changed

| File | Change |
|---|---|
| `html/MSD_Calculation.html` | `min="1"` on both turn inputs; override checkbox inside each warning badge; min-applied note elements in results |
| `html/js/msd_calculation.js` | Remove `< 50` blocking; `override` param in `computeFlyby`; read checkbox; show note in `renderWPResults`; reset on type change; extra rows in `copyToWord` |

