### PR TITLE
Feat/96 rod timing calculator

### DIFF
--- a/html/Main.html
+++ b/html/Main.html
@@ -894,6 +894,34 @@
                     >
                   </button>
                 </li>
+                <li>
+                  <button
+                    id="rodButton"
+                    data-label="GS / Rate of Descent"
+                    onclick="loadPage('rod_timing.html', this)"
+                    class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
+                  >
+                    <svg
+                      class="text-primary-400 w-5 h-5 mr-3 sidebar-icon"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                      <line x1="3" y1="9" x2="21" y2="9"></line>
+                      <line x1="3" y1="15" x2="21" y2="15"></line>
+                      <line x1="9" y1="9" x2="9" y2="21"></line>
+                    </svg>
+                    <span class="sidebar-label" data-i18n="rod.sidebarLabel"
+                      >GS / Rate of Descent</span
+                    >
+                  </button>
+                </li>
                 <li class="sub-section-label" aria-hidden="true">
                   <span data-i18n="sections.subApproach"
                     >Approach &amp; Manoeuvring</span

--- a/html/aviation-utils.js
+++ b/html/aviation-utils.js
@@ -231,7 +231,11 @@ function createHTMLTable(data, title) {
   `;
 
   for (const [key, value] of Object.entries(data)) {
-    htmlContent += `<tr><td style="padding:8px;text-align:left">${key}</td><td style="padding:8px;text-align:left">${value}</td></tr>`;
+    if (value === "__section__") {
+      htmlContent += `<tr style="background:#1e3a5f;color:#ffffff"><td colspan="2" style="padding:6px 8px;font-weight:bold">${key}</td></tr>`;
+    } else {
+      htmlContent += `<tr><td style="padding:8px;text-align:left">${key}</td><td style="padding:8px;text-align:left">${value}</td></tr>`;
+    }
   }
 
   htmlContent += `</table>`;

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -278,6 +278,33 @@
     "formulaRef": "PANS-OPS Formula Reference",
     "globalParams": "Global Parameters"
   },
+  "rod": {
+    "title": "GS / Rate of Descent Table Builder",
+    "sidebarLabel": "GS / Rate of Descent",
+    "tableParams": "Table Parameters",
+    "distance": "Distance (NM)",
+    "gradient": "Gradient (%)",
+    "titleRow": "Title Row",
+    "footerRow": "Footer Row",
+    "timingLabel": "Timing Label",
+    "rodLabel": "ROD Label",
+    "gsUnit": "GS Unit",
+    "timingUnit": "Timing Unit",
+    "gsValues": "GS Values",
+    "gsValuesHint": "Comma-separated integers (knots)",
+    "phDistance": "e.g. 5.2",
+    "phGradient": "e.g. 5.3",
+    "phTitleRow": "e.g. Rate of Descent",
+    "phFooterRow": "Leave blank to omit",
+    "phTimingLabel": "Auto",
+    "phRODLabel": "Auto",
+    "phGSUnit": "KT",
+    "phTimingUnit": "min:s",
+    "phGSValues": "e.g. 70, 90, 100, 120, 140, 160",
+    "previewTitle": "Preview",
+    "buildTable": "Build Table",
+    "addTable": "Add"
+  },
   "windSpiral": {
     "title": "Wind Spiral Calculator"
   },

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -278,6 +278,33 @@
     "formulaRef": "Referencia de Fórmulas PANS-OPS",
     "globalParams": "Parámetros Globales"
   },
+  "rod": {
+    "title": "Constructor de Tabla GS / Razón de Descenso",
+    "sidebarLabel": "GS / Razón de Descenso",
+    "tableParams": "Parámetros de tabla",
+    "distance": "Distancia (NM)",
+    "gradient": "Gradiente (%)",
+    "titleRow": "Fila de título",
+    "footerRow": "Fila de pie",
+    "timingLabel": "Etiqueta de tiempo",
+    "rodLabel": "Etiqueta ROD",
+    "gsUnit": "Unidad GS",
+    "timingUnit": "Unidad de tiempo",
+    "gsValues": "Valores GS",
+    "gsValuesHint": "Enteros separados por comas (nudos)",
+    "phDistance": "ej. 5.2",
+    "phGradient": "ej. 5.3",
+    "phTitleRow": "ej. Razón de Descenso",
+    "phFooterRow": "Dejar en blanco para omitir",
+    "phTimingLabel": "Auto",
+    "phRODLabel": "Auto",
+    "phGSUnit": "KT",
+    "phTimingUnit": "min:s",
+    "phGSValues": "ej. 70, 90, 100, 120, 140, 160",
+    "previewTitle": "Vista previa",
+    "buildTable": "Construir tabla",
+    "addTable": "Agregar"
+  },
   "windSpiral": {
     "title": "Calculadora de Espiral de Viento"
   },

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -707,16 +707,17 @@ function copyToWord() {
     }
   }
 
-  // Rename WP1/WP2 key prefixes to use custom names
-  var renamedWp1 = {};
+  // Build final rows with named section headers, stripping WP1/WP2 prefix from keys
+  var allRows = {};
+  allRows[wp1Name + " — IAF"] = "__section__";
   Object.keys(wp1Rows).forEach(function (k) {
-    renamedWp1[k.slice(0, 3) === "WP1" ? wp1Name + k.slice(3) : k] = wp1Rows[k];
+    allRows[k.startsWith("WP1 ") ? k.slice(4) : k] = wp1Rows[k];
   });
-  var renamedWp2 = {};
+  allRows[wp2Name + " — IF"] = "__section__";
   Object.keys(wp2Rows).forEach(function (k) {
-    renamedWp2[k.slice(0, 3) === "WP2" ? wp2Name + k.slice(3) : k] = wp2Rows[k];
+    allRows[k.startsWith("WP2 ") ? k.slice(4) : k] = wp2Rows[k];
   });
-  var allRows = Object.assign({}, renamedWp1, renamedWp2, combinedRows);
+  Object.assign(allRows, combinedRows);
   var htmlContent = createHTMLTable(
     allRows,
     "MSD Combined \u2014 PANS-OPS Vol II \u00A7 1.4.2",

--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -1,0 +1,458 @@
+// ─── Constants ────────────────────────────────────────────────────────────────
+var NM_TO_FT_ROD = 6068.0; // empirically derived for ICAO chart table compatibility
+
+// ─── Core formulas ────────────────────────────────────────────────────────────
+function formatSeconds(totalSeconds, unit) {
+  if (unit === "s") return Math.round(totalSeconds).toString();
+  if (unit === "min") return (totalSeconds / 60).toFixed(2);
+  var mins = Math.floor(totalSeconds / 60);
+  var secs = Math.round(totalSeconds % 60);
+  if (secs === 60) { mins++; secs = 0; }
+  return mins + ":" + (secs < 10 ? "0" : "") + secs;
+}
+
+function computeTiming(distanceNM, gsKt, unit) {
+  return formatSeconds((distanceNM / gsKt) * 3600, unit || "min:s");
+}
+
+function computeROD(gsKt, gradientPct) {
+  return Math.floor((gsKt * gradientPct * NM_TO_FT_ROD) / 100 / 60);
+}
+
+function parseGSValues(raw) {
+  var out = [];
+  raw.split(",").forEach(function (s) {
+    var n = parseInt(s.trim(), 10);
+    if (!isNaN(n) && n > 0) out.push(n);
+  });
+  return out;
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+// ─── State ────────────────────────────────────────────────────────────────────
+var tableBlocks = [];
+
+// block shape:
+// {
+//   title   : string,
+//   footer  : string,
+//   gsLabel : string,   // "Ground Speed" header
+//   gsUnit  : string,   // "KT"
+//   gsColumns: string[], // ["70","90",…]
+//   rows    : [{ label, unit, values: string[] }]
+// }
+
+// ─── Build a block from current form inputs ───────────────────────────────────
+function createBlockFromInputs() {
+  var distance   = parseFloat(document.getElementById("rodDistance").value);
+  var gradient   = parseFloat(document.getElementById("rodGradient").value);
+  var timingUnit = document.getElementById("rodTimingUnit").value;
+  var gsUnit     = document.getElementById("rodGSUnit").value || "KT";
+  var gsValues   = parseGSValues(document.getElementById("rodGSValues").value);
+  var timingLabelInput = document.getElementById("rodTimingLabel").value.trim();
+  var rodLabelInput    = document.getElementById("rodRODLabel").value.trim();
+
+  var timingLabel = timingLabelInput || "FAF-MAPt " + distance + "NM";
+  var rodLabel    = rodLabelInput    || "Rate of Descent " + gradient + "%";
+
+  return {
+    title    : document.getElementById("rodTitleRow").value.trim(),
+    footer   : document.getElementById("rodFooterRow").value.trim(),
+    gsLabel  : "Ground Speed",
+    gsUnit   : gsUnit,
+    gsColumns: gsValues.map(String),
+    rows: [
+      {
+        label : timingLabel,
+        unit  : timingUnit,
+        values: gsValues.map(function (gs) { return computeTiming(distance, gs, timingUnit); })
+      },
+      {
+        label : rodLabel,
+        unit  : "ft/min",
+        values: gsValues.map(function (gs) { return String(computeROD(gs, gradient)); })
+      }
+    ]
+  };
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+function validateInputs() {
+  var distance = parseFloat(document.getElementById("rodDistance").value);
+  var gradient = parseFloat(document.getElementById("rodGradient").value);
+  if (isNaN(distance) || distance <= 0) {
+    showToast("Please enter a valid distance (NM > 0).", "error"); return false;
+  }
+  if (isNaN(gradient) || gradient <= 0 || gradient > 30) {
+    showToast("Please enter a gradient between 0.1% and 30%.", "error"); return false;
+  }
+  if (parseGSValues(document.getElementById("rodGSValues").value).length === 0) {
+    showToast("Please enter at least one valid GS value.", "error"); return false;
+  }
+  return true;
+}
+
+// ─── Build / Add ──────────────────────────────────────────────────────────────
+function buildTable() {
+  if (!validateInputs()) return;
+  tableBlocks = [createBlockFromInputs()];
+  renderAllBlocks();
+  document.getElementById("rodEditor").classList.add("visible");
+  document.getElementById("rodApp").classList.add("split");
+  document.getElementById("btnAddBlock").disabled = false;
+}
+
+function addBlock() {
+  if (!validateInputs()) return;
+  tableBlocks.push(createBlockFromInputs());
+  renderAllBlocks();
+  // scroll editor into view on mobile
+  document.getElementById("rodEditor").scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+function renderAllBlocks() {
+  var container = document.getElementById("rodBlocks");
+  container.innerHTML = "";
+  tableBlocks.forEach(function (block, bi) {
+    var el = buildBlockElement(block, bi);
+    container.appendChild(el);
+    attachCellListeners(el, bi);
+  });
+}
+
+function buildBlockElement(block, bi) {
+  var nCols     = block.gsColumns.length;
+  var totalCols = nCols + 4; // row-ctrl | label | unit | gsColumns… | del
+
+  var h = "";
+
+  h += '<div class="rod-block">';
+  h += '<div style="overflow-x:auto">';
+  h += '<table class="rod-table">';
+
+  // ── Title row (always editable) ──────────────────────────────────────────
+  h += '<tr>';
+  h += '<td colspan="' + totalCols + '" contenteditable="true" ' +
+    'data-field="title" data-block="' + bi + '" data-ph="Title (leave blank to hide)" ' +
+    'style="background:#0c2240;color:#fff;padding:7px 10px;font-weight:bold;font-size:13px">' +
+    escapeHtml(block.title) + '</td>';
+  h += '</tr>';
+
+  // ── Column control row (← → ×, + add col) ───────────────────────────────
+  h += '<tr style="background:rgba(15,23,42,0.35)">';
+  h += '<td></td>'; // row-ctrl spacer
+  h += '<td></td>'; // label spacer
+  h += '<td></td>'; // unit spacer
+  block.gsColumns.forEach(function (_, ci) {
+    h += '<td style="padding:2px 3px;text-align:center;white-space:nowrap">';
+    h += cbtn("←", "moveCol(" + bi + "," + ci + ",-1)", ci === 0);
+    h += " ";
+    h += cbtn("→", "moveCol(" + bi + "," + ci + ",1)", ci === nCols - 1);
+    h += " ";
+    h += cbtn("×", "delCol(" + bi + "," + ci + ")", false, true);
+    h += '</td>';
+  });
+  h += '<td style="padding:2px 3px;text-align:center">';
+  h += '<button type="button" class="rod-add-col-btn" onclick="addCol(' + bi + ')" title="Add column">+</button>';
+  h += '</td>';
+  h += '</tr>';
+
+  // ── GS header row ────────────────────────────────────────────────────────
+  h += '<tr style="background:#0c2240;color:#fff">';
+  h += '<td style="width:22px;padding:2px"></td>'; // row-ctrl spacer
+  h += '<th contenteditable="true" data-field="gsLabel" data-block="' + bi + '" ' +
+    'style="padding:7px 10px;text-align:left;font-weight:bold;white-space:nowrap;min-width:130px">' +
+    escapeHtml(block.gsLabel) + '</th>';
+  h += '<th contenteditable="true" data-field="gsUnit" data-block="' + bi + '" ' +
+    'style="padding:7px 10px;text-align:left;font-weight:bold;min-width:46px">' +
+    escapeHtml(block.gsUnit) + '</th>';
+  block.gsColumns.forEach(function (gs, ci) {
+    h += '<th contenteditable="true" data-field="gsCol" data-block="' + bi + '" data-col="' + ci + '" ' +
+      'style="padding:7px 10px;text-align:right;font-weight:bold;min-width:46px">' +
+      escapeHtml(gs) + '</th>';
+  });
+  h += '<td style="width:22px;padding:2px"></td>'; // del spacer
+  h += '</tr>';
+
+  // ── Data rows ────────────────────────────────────────────────────────────
+  block.rows.forEach(function (row, ri) {
+    var isFirst = ri === 0;
+    var isLast  = ri === block.rows.length - 1;
+    h += '<tr style="border-bottom:1px solid rgba(148,163,184,0.18)">';
+
+    // row move buttons
+    h += '<td style="padding:1px 2px;white-space:nowrap;width:22px;vertical-align:middle">';
+    h += rbtn("↑", "moveRow(" + bi + "," + ri + ",-1)", isFirst);
+    h += rbtn("↓", "moveRow(" + bi + "," + ri + ",1)", isLast);
+    h += '</td>';
+
+    // label
+    h += '<td contenteditable="true" data-field="rowLabel" data-block="' + bi + '" data-row="' + ri + '" ' +
+      'data-ph="Row label" style="padding:7px 10px;font-weight:500;white-space:nowrap">' +
+      escapeHtml(row.label) + '</td>';
+
+    // unit
+    h += '<td contenteditable="true" data-field="rowUnit" data-block="' + bi + '" data-row="' + ri + '" ' +
+      'data-ph="unit" style="padding:7px 10px;color:#94a3b8;min-width:46px">' +
+      escapeHtml(row.unit) + '</td>';
+
+    // values
+    row.values.forEach(function (val, ci) {
+      h += '<td contenteditable="true" data-field="rowVal" data-block="' + bi + '" data-row="' + ri + '" data-col="' + ci + '" ' +
+        'style="padding:7px 10px;text-align:right">' +
+        escapeHtml(val) + '</td>';
+    });
+
+    // delete row
+    h += '<td style="padding:1px 2px;text-align:center;vertical-align:middle;width:22px">';
+    h += '<button type="button" class="rod-cbtn danger" onclick="delRow(' + bi + ',' + ri + ')" title="Delete row">×</button>';
+    h += '</td>';
+
+    h += '</tr>';
+  });
+
+  // ── Add row ──────────────────────────────────────────────────────────────
+  h += '<tr style="border-top:1px solid rgba(148,163,184,0.12)">';
+  h += '<td colspan="' + totalCols + '" style="padding:5px 8px">';
+  h += '<button type="button" class="rod-add-row-btn" onclick="addRow(' + bi + ')">+ Add Row</button>';
+  h += '</td>';
+  h += '</tr>';
+
+  // ── Footer row (always editable) ─────────────────────────────────────────
+  h += '<tr>';
+  h += '<td colspan="' + totalCols + '" contenteditable="true" ' +
+    'data-field="footer" data-block="' + bi + '" data-ph="Footer (leave blank to hide)" ' +
+    'style="padding:7px 10px;font-style:italic;color:#94a3b8;font-size:12px">' +
+    escapeHtml(block.footer) + '</td>';
+  h += '</tr>';
+
+  h += '</table>';
+  h += '</div>'; // overflow-x
+
+  // delete block button (only when >1 block)
+  if (tableBlocks.length > 1) {
+    h += '<div style="text-align:right;margin-top:6px">';
+    h += '<button type="button" class="rod-del-block-btn" onclick="delBlock(' + bi + ')">Remove this table</button>';
+    h += '</div>';
+  }
+
+  h += '</div>'; // rod-block
+
+  var wrapper = document.createElement("div");
+  wrapper.innerHTML = h;
+  return wrapper.firstChild;
+}
+
+// Small helper for column control buttons
+function cbtn(label, onclick, disabled, isDanger) {
+  var cls = "rod-cbtn" + (isDanger ? " danger" : "");
+  return '<button type="button" class="' + cls + '" onclick="' + onclick + '"' +
+    (disabled ? " disabled" : "") + '>' + label + '</button>';
+}
+
+// Small helper for row move buttons
+function rbtn(label, onclick, disabled) {
+  return '<button type="button" class="rod-cbtn" onclick="' + onclick + '"' +
+    (disabled ? " disabled" : "") + ' style="display:block;margin:1px auto">' + label + '</button>';
+}
+
+// ─── Cell edit → state sync ───────────────────────────────────────────────────
+function attachCellListeners(container, bi) {
+  container.querySelectorAll("[contenteditable][data-field]").forEach(function (el) {
+    el.addEventListener("input", function () {
+      var block = tableBlocks[parseInt(el.dataset.block, 10)];
+      if (!block) return;
+      var val = el.textContent;
+      switch (el.dataset.field) {
+        case "title":   block.title = val; break;
+        case "footer":  block.footer = val; break;
+        case "gsLabel": block.gsLabel = val; break;
+        case "gsUnit":  block.gsUnit = val; break;
+        case "gsCol":
+          block.gsColumns[parseInt(el.dataset.col, 10)] = val; break;
+        case "rowLabel":
+          block.rows[parseInt(el.dataset.row, 10)].label = val; break;
+        case "rowUnit":
+          block.rows[parseInt(el.dataset.row, 10)].unit = val; break;
+        case "rowVal":
+          block.rows[parseInt(el.dataset.row, 10)].values[parseInt(el.dataset.col, 10)] = val; break;
+      }
+    });
+  });
+}
+
+// ─── Mutations (exposed globally for inline onclick) ─────────────────────────
+function moveRow(bi, ri, dir) {
+  var rows = tableBlocks[bi].rows;
+  var ni = ri + dir;
+  if (ni < 0 || ni >= rows.length) return;
+  var tmp = rows[ri]; rows[ri] = rows[ni]; rows[ni] = tmp;
+  renderAllBlocks();
+}
+
+function delRow(bi, ri) {
+  tableBlocks[bi].rows.splice(ri, 1);
+  renderAllBlocks();
+}
+
+function addRow(bi) {
+  var block = tableBlocks[bi];
+  block.rows.push({ label: "", unit: "", values: block.gsColumns.map(function () { return ""; }) });
+  renderAllBlocks();
+}
+
+function moveCol(bi, ci, dir) {
+  var block = tableBlocks[bi];
+  var ni = ci + dir;
+  if (ni < 0 || ni >= block.gsColumns.length) return;
+  var tmp = block.gsColumns[ci];
+  block.gsColumns[ci] = block.gsColumns[ni];
+  block.gsColumns[ni] = tmp;
+  block.rows.forEach(function (row) {
+    var tv = row.values[ci]; row.values[ci] = row.values[ni]; row.values[ni] = tv;
+  });
+  renderAllBlocks();
+}
+
+function delCol(bi, ci) {
+  var block = tableBlocks[bi];
+  block.gsColumns.splice(ci, 1);
+  block.rows.forEach(function (row) { row.values.splice(ci, 1); });
+  renderAllBlocks();
+}
+
+function addCol(bi) {
+  var block = tableBlocks[bi];
+  block.gsColumns.push("");
+  block.rows.forEach(function (row) { row.values.push(""); });
+  renderAllBlocks();
+}
+
+function delBlock(bi) {
+  tableBlocks.splice(bi, 1);
+  if (tableBlocks.length === 0) {
+    document.getElementById("rodEditor").classList.remove("visible");
+    document.getElementById("rodApp").classList.remove("split");
+    document.getElementById("btnAddBlock").disabled = true;
+  } else {
+    renderAllBlocks();
+  }
+}
+
+// ─── Word export (from state) ─────────────────────────────────────────────────
+function buildWordHTML() {
+  return tableBlocks.map(function (block) {
+    var nCols     = block.gsColumns.length;
+    var totalCols = nCols + 2;
+    var rows = "";
+
+    if (block.title) {
+      rows += '<tr style="background:#0c2240;color:#fff"><td colspan="' + totalCols +
+        '" style="padding:7px 10px;font-weight:bold;font-size:11pt">' + escapeHtml(block.title) + '</td></tr>';
+    }
+
+    rows += '<tr style="background:#0c2240;color:#fff">';
+    rows += '<th style="padding:7px 10px;text-align:left;font-weight:bold">' + escapeHtml(block.gsLabel || "Ground Speed") + '</th>';
+    rows += '<th style="padding:7px 10px;text-align:left;font-weight:bold">' + escapeHtml(block.gsUnit) + '</th>';
+    block.gsColumns.forEach(function (gs) {
+      rows += '<th style="padding:7px 10px;text-align:right;font-weight:bold">' + escapeHtml(gs) + '</th>';
+    });
+    rows += '</tr>';
+
+    block.rows.forEach(function (row) {
+      rows += '<tr>';
+      rows += '<td style="padding:7px 10px;font-weight:500">' + escapeHtml(row.label) + '</td>';
+      rows += '<td style="padding:7px 10px">' + escapeHtml(row.unit) + '</td>';
+      row.values.forEach(function (v) {
+        rows += '<td style="padding:7px 10px;text-align:right">' + escapeHtml(v) + '</td>';
+      });
+      rows += '</tr>';
+    });
+
+    if (block.footer) {
+      rows += '<tr><td colspan="' + totalCols + '" style="padding:7px 10px;font-style:italic">' +
+        escapeHtml(block.footer) + '</td></tr>';
+    }
+
+    return '<table border="1" style="border-collapse:collapse;width:100%;font-family:Calibri,Arial,sans-serif;font-size:11pt">' +
+      rows + '</table>';
+  }).join("<br><br>");
+}
+
+function copyToWord() {
+  if (tableBlocks.length === 0) { showToast("Build the table first.", "error"); return; }
+  copyToClipboard(buildWordHTML());
+}
+
+// ─── Save / Load ──────────────────────────────────────────────────────────────
+function saveParameters() {
+  var data = {
+    distance   : document.getElementById("rodDistance").value,
+    gradient   : document.getElementById("rodGradient").value,
+    titleRow   : document.getElementById("rodTitleRow").value,
+    footerRow  : document.getElementById("rodFooterRow").value,
+    timingLabel: document.getElementById("rodTimingLabel").value,
+    rodLabel   : document.getElementById("rodRODLabel").value,
+    gsUnit     : document.getElementById("rodGSUnit").value,
+    timingUnit : document.getElementById("rodTimingUnit").value,
+    gsValues   : document.getElementById("rodGSValues").value,
+  };
+  var ts   = new Date().toISOString().replace(/[:.]/g, "-");
+  var blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  var a    = document.createElement("a");
+  a.href   = URL.createObjectURL(blob);
+  a.download = ts + "_rod_timing.json";
+  a.click();
+}
+
+function loadParameters(event) {
+  var file = event.target.files[0];
+  if (!file) return;
+  var reader = new FileReader();
+  reader.onload = function (e) {
+    try {
+      var d = JSON.parse(e.target.result);
+      if (d.distance    != null) document.getElementById("rodDistance").value    = d.distance;
+      if (d.gradient    != null) document.getElementById("rodGradient").value    = d.gradient;
+      if (d.titleRow    != null) document.getElementById("rodTitleRow").value    = d.titleRow;
+      if (d.footerRow   != null) document.getElementById("rodFooterRow").value   = d.footerRow;
+      if (d.timingLabel != null) document.getElementById("rodTimingLabel").value = d.timingLabel;
+      if (d.rodLabel    != null) document.getElementById("rodRODLabel").value    = d.rodLabel;
+      if (d.gsUnit      != null) document.getElementById("rodGSUnit").value      = d.gsUnit;
+      if (d.timingUnit  != null) document.getElementById("rodTimingUnit").value  = d.timingUnit;
+      if (d.gsValues    != null) document.getElementById("rodGSValues").value    = d.gsValues;
+      showToast("Parameters successfully loaded!", "success");
+    } catch (_) {
+      showToast("Invalid JSON file.", "error");
+    }
+  };
+  reader.readAsText(file);
+}
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
+document.addEventListener("DOMContentLoaded", function () {
+  checkDarkMode();
+
+  document.getElementById("btnSave").addEventListener("click", saveParameters);
+  document.getElementById("btnLoad").addEventListener("click", function () {
+    document.getElementById("loadFile").click();
+  });
+  document.getElementById("loadFile").addEventListener("change", loadParameters);
+  document.getElementById("btnCalcROD").addEventListener("click", buildTable);
+  document.getElementById("btnAddBlock").addEventListener("click", addBlock);
+  document.getElementById("btnCopy").addEventListener("click", copyToWord);
+});
+
+(function () {
+  function initI18n() {
+    if (window.I18N) I18N.init({ defaultLang: "en", supported: ["en", "es"], path: "i18n" }).catch(console.error);
+  }
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", initI18n);
+  else initI18n();
+})();

--- a/html/rod_timing.html
+++ b/html/rod_timing.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title data-i18n="rod.title">GS / Rate of Descent Table Builder</title>
+    <script src="suppress-tailwind-warn.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="shared-config.js"></script>
+    <link rel="stylesheet" href="dark-mode.css" />
+    <script src="aviation-utils.js"></script>
+    <script src="i18n/i18n.js"></script>
+    <style>
+      /* ── Layout ─────────────────────────────────────── */
+      #rodApp {
+        display: grid;
+        gap: 1.25rem;
+        align-items: start;
+        transition: grid-template-columns 360ms cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      #rodFormPanel {
+        max-width: 42rem;
+        margin-left: auto;
+        margin-right: auto;
+        width: 100%;
+        transition: max-width 360ms cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      #rodApp.split #rodFormPanel {
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+      }
+      #rodApp.split {
+        grid-template-columns: 340px 1fr;
+      }
+      @media (max-width: 800px) {
+        #rodApp.split {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      /* ── Editor panel ───────────────────────────────── */
+      #rodEditor {
+        display: none;
+        min-width: 0;
+      }
+      #rodEditor.visible {
+        display: block;
+      }
+
+      /* ── Table ──────────────────────────────────────── */
+      .rod-table {
+        border-collapse: collapse;
+        width: 100%;
+        font-family: Calibri, Arial, sans-serif;
+        font-size: 13px;
+        border: 2px solid rgba(100, 116, 139, 0.55);
+      }
+      .rod-table td,
+      .rod-table th {
+        border: 1px solid rgba(100, 116, 139, 0.35);
+      }
+      .rod-table [contenteditable] {
+        outline: none;
+        cursor: text;
+        border-radius: 3px;
+        transition: box-shadow 120ms, background 120ms;
+      }
+      .rod-table [contenteditable]:focus {
+        box-shadow: inset 0 0 0 2px rgba(99, 102, 241, 0.6);
+        background: rgba(99, 102, 241, 0.1) !important;
+      }
+      .rod-table [contenteditable][data-ph]:empty:before {
+        content: attr(data-ph);
+        color: #64748b;
+        pointer-events: none;
+        font-style: italic;
+      }
+
+      /* ── Control buttons — light mode ───────────────── */
+      .rod-cbtn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        font-size: 12px;
+        font-weight: 700;
+        border-radius: 4px;
+        border: 1px solid #d1d5db;
+        background: #f1f5f9;
+        color: #374151;
+        cursor: pointer;
+        line-height: 1;
+        transition: background 120ms, color 120ms, border-color 120ms;
+        vertical-align: middle;
+      }
+      .rod-cbtn:hover:not(:disabled) {
+        background: rgba(99, 102, 241, 0.12);
+        border-color: rgba(99, 102, 241, 0.5);
+        color: #4338ca;
+      }
+      .rod-cbtn:disabled {
+        opacity: 0.25;
+        cursor: default;
+      }
+      .rod-cbtn.danger {
+        background: #fee2e2;
+        border-color: rgba(239, 68, 68, 0.5);
+        color: #dc2626;
+      }
+      .rod-cbtn.danger:hover:not(:disabled) {
+        background: #fecaca;
+        border-color: #ef4444;
+        color: #991b1b;
+      }
+
+      /* dark mode overrides */
+      .dark .rod-cbtn {
+        background: rgba(51, 65, 85, 0.65);
+        border-color: rgba(148, 163, 184, 0.4);
+        color: #cbd5e1;
+      }
+      .dark .rod-cbtn:hover:not(:disabled) {
+        background: rgba(99, 102, 241, 0.5);
+        border-color: rgba(99, 102, 241, 0.7);
+        color: #e0e7ff;
+      }
+      .dark .rod-cbtn.danger {
+        background: rgba(127, 29, 29, 0.45);
+        border-color: rgba(239, 68, 68, 0.5);
+        color: #fca5a5;
+      }
+      .dark .rod-cbtn.danger:hover:not(:disabled) {
+        background: rgba(239, 68, 68, 0.5);
+        border-color: rgba(239, 68, 68, 0.8);
+        color: #fff;
+      }
+
+      /* ── Column control row background ───────────────── */
+      .rod-col-ctrl-tr { background: #f1f5f9; }
+      .dark .rod-col-ctrl-tr { background: rgba(15, 23, 42, 0.35); }
+
+      /* ── Unit cell color ──────────────────────────────── */
+      .rod-unit-cell { color: #6b7280; }
+      .dark .rod-unit-cell { color: #94a3b8; }
+
+      /* ── Add row / col buttons — light mode ──────────── */
+      .rod-add-row-btn,
+      .rod-add-col-btn {
+        font-size: 11px;
+        font-weight: 600;
+        padding: 4px 12px;
+        border-radius: 5px;
+        border: 1px dashed #9ca3af;
+        background: #f9fafb;
+        color: #6b7280;
+        cursor: pointer;
+        transition: border-color 120ms, color 120ms, background 120ms;
+        white-space: nowrap;
+      }
+      .rod-add-row-btn:hover,
+      .rod-add-col-btn:hover {
+        border-color: #6366f1;
+        color: #4338ca;
+        background: rgba(99, 102, 241, 0.08);
+      }
+      .dark .rod-add-row-btn,
+      .dark .rod-add-col-btn {
+        border-color: rgba(148, 163, 184, 0.55);
+        background: rgba(51, 65, 85, 0.3);
+        color: #94a3b8;
+      }
+      .dark .rod-add-row-btn:hover,
+      .dark .rod-add-col-btn:hover {
+        border-color: rgba(99, 102, 241, 0.7);
+        color: #c7d2fe;
+        background: rgba(99, 102, 241, 0.15);
+      }
+
+      /* ── Delete block button ──────────────────────────── */
+      .rod-del-block-btn {
+        font-size: 11px;
+        font-weight: 600;
+        padding: 3px 10px;
+        border-radius: 4px;
+        border: 1px solid rgba(239, 68, 68, 0.55);
+        background: #fee2e2;
+        color: #dc2626;
+        cursor: pointer;
+        transition: background 120ms, border-color 120ms;
+      }
+      .rod-del-block-btn:hover {
+        background: #fecaca;
+        border-color: #ef4444;
+      }
+      .dark .rod-del-block-btn {
+        background: rgba(127, 29, 29, 0.25);
+        color: #fca5a5;
+        border-color: rgba(239, 68, 68, 0.5);
+      }
+      .dark .rod-del-block-btn:hover {
+        background: rgba(239, 68, 68, 0.25);
+        border-color: rgba(239, 68, 68, 0.8);
+      }
+
+      /* ── Block separator ────────────────────────────── */
+      .rod-block + .rod-block {
+        margin-top: 1.75rem;
+        padding-top: 1.75rem;
+        border-top: 2px solid rgba(100, 116, 139, 0.3);
+      }
+
+      /* ── Add button disabled state ──────────────────── */
+      #btnAddBlock:disabled {
+        opacity: 0.4;
+        cursor: default;
+      }
+    </style>
+  </head>
+
+  <body class="bg-gray-50 dark:bg-gray-900 min-h-screen p-4">
+    <div id="rodApp">
+
+      <!-- ═══════════════════════════════════════════════
+           LEFT PANEL — Calculator form
+      ════════════════════════════════════════════════ -->
+      <div id="rodFormPanel">
+        <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700 p-5">
+
+          <!-- Header -->
+          <header class="mb-5">
+            <h1 class="text-xl sm:text-2xl font-bold text-primary-700 dark:text-primary-300 flex items-center gap-2">
+              <svg class="w-6 h-6 shrink-0 text-primary-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+                <line x1="3" y1="9" x2="21" y2="9"></line>
+                <line x1="3" y1="15" x2="21" y2="15"></line>
+                <line x1="9" y1="9" x2="9" y2="21"></line>
+              </svg>
+              <span data-i18n="rod.title">GS / Rate of Descent Table Builder</span>
+            </h1>
+          </header>
+
+          <!-- Save / Load -->
+          <div class="flex flex-wrap gap-2 mb-5">
+            <button id="btnSave" type="button"
+              class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors">
+              <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                <polyline points="17 21 17 13 7 13 7 21"></polyline>
+                <polyline points="7 3 7 8 15 8"></polyline>
+              </svg>
+              <span data-i18n="common.save">Save</span>
+            </button>
+            <button id="btnLoad" type="button"
+              class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors">
+              <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="17 8 12 3 7 8"></polyline>
+                <line x1="12" y1="3" x2="12" y2="15"></line>
+              </svg>
+              <span data-i18n="common.load">Load</span>
+            </button>
+            <input id="loadFile" type="file" accept=".json" class="hidden" />
+          </div>
+
+          <!-- Inputs -->
+          <fieldset>
+            <legend class="sr-only" data-i18n="rod.tableParams">Table Parameters</legend>
+
+            <div class="grid grid-cols-2 gap-3 mb-4">
+              <div>
+                <label for="rodDistance"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.distance">Distance (NM)</label>
+                <input id="rodDistance" type="number" step="0.1" min="0.1"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  data-i18n-attr="placeholder" data-i18n="rod.phDistance" placeholder="e.g. 5.2" />
+              </div>
+              <div>
+                <label for="rodGradient"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.gradient">Gradient (%)</label>
+                <input id="rodGradient" type="number" step="0.1" min="0.1" max="30"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  data-i18n-attr="placeholder" data-i18n="rod.phGradient" placeholder="e.g. 5.3" />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3 mb-4">
+              <div>
+                <label for="rodTitleRow"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.titleRow">Title Row</label>
+                <input id="rodTitleRow" type="text"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  data-i18n-attr="placeholder" data-i18n="rod.phTitleRow" placeholder="e.g. Rate of Descent" />
+              </div>
+              <div>
+                <label for="rodFooterRow"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.footerRow">Footer Row</label>
+                <input id="rodFooterRow" type="text"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  data-i18n-attr="placeholder" data-i18n="rod.phFooterRow" placeholder="Leave blank to omit" />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3 mb-4">
+              <div>
+                <label for="rodTimingLabel"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.timingLabel">Timing Label</label>
+                <input id="rodTimingLabel" type="text"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  data-i18n-attr="placeholder" data-i18n="rod.phTimingLabel" placeholder="Auto" />
+              </div>
+              <div>
+                <label for="rodRODLabel"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.rodLabel">ROD Label</label>
+                <input id="rodRODLabel" type="text"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  data-i18n-attr="placeholder" data-i18n="rod.phRODLabel" placeholder="Auto" />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3 mb-4">
+              <div>
+                <label for="rodGSUnit"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.gsUnit">GS Unit</label>
+                <select id="rodGSUnit"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500">
+                  <option value="KT" selected>KT</option>
+                  <option value="km/h">km/h</option>
+                </select>
+              </div>
+              <div>
+                <label for="rodTimingUnit"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                  data-i18n="rod.timingUnit">Timing Unit</label>
+                <select id="rodTimingUnit"
+                  class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500">
+                  <option value="min:s" selected>min:s</option>
+                  <option value="min">min</option>
+                  <option value="s">s</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="mb-4">
+              <label for="rodGSValues"
+                class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1"
+                data-i18n="rod.gsValues">GS Values</label>
+              <input id="rodGSValues" type="text" value="70, 90, 100, 120, 140, 160"
+                class="w-full px-2.5 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                data-i18n-attr="placeholder" data-i18n="rod.phGSValues" placeholder="e.g. 70, 90, 100, 120, 140, 160" />
+              <p class="mt-1 text-xs text-gray-400" data-i18n="rod.gsValuesHint">Comma-separated integers (knots)</p>
+            </div>
+          </fieldset>
+
+          <!-- Action buttons -->
+          <div class="flex gap-2 justify-end mt-2">
+            <button id="btnCalcROD" type="button"
+              class="px-5 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-semibold rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
+              <span data-i18n="rod.buildTable">Build Table</span>
+            </button>
+            <button id="btnAddBlock" type="button" disabled
+              class="px-5 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-600 text-white text-sm font-semibold rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
+              <span data-i18n="rod.addTable">Add</span>
+            </button>
+          </div>
+
+        </div>
+      </div><!-- /rodFormPanel -->
+
+      <!-- ═══════════════════════════════════════════════
+           RIGHT PANEL — Table editor
+      ════════════════════════════════════════════════ -->
+      <div id="rodEditor" role="region" aria-live="polite" aria-atomic="false">
+        <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700 p-5">
+
+          <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+            <h2 class="text-lg font-bold text-gray-800 dark:text-white flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-primary-500 inline-block"></span>
+              <span data-i18n="rod.previewTitle">Preview</span>
+            </h2>
+            <button id="btnCopy" type="button"
+              class="flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors">
+              <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <span data-i18n="common.copyToWord">Copy to Word</span>
+            </button>
+          </div>
+
+          <div id="rodBlocks" class="overflow-x-auto"></div>
+
+        </div>
+      </div><!-- /rodEditor -->
+
+    </div><!-- /rodApp -->
+
+    <script src="js/rod_timing.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
# feat(#96): GS / Rate of Descent Table Builder

## Branch

`feat/96-rod-timing-calculator`

## Closes

Issue #96 — Bring Rate of Descent / Timing Calculation logic from qPANSOPY to the webapp.

---

## Summary

Adds a new **GS / Rate of Descent Table Builder** calculator that generates timing and rate-of-descent tables for instrument approach procedures (FAF–MAPt segment).

The user inputs a distance (NM), descent gradient (%), and a list of ground speed values; the calculator produces a formatted table with timing (MM:SS) and rate of descent (ft/min) for each GS column. The table can be customised with optional title/footer rows and label overrides, and exported to Word via Copy to Clipboard.

<img width="1920" height="1080" alt="{1F4AD85A-5936-4DDB-9EA2-A1D329BB8DF9}" src="https://github.com/user-attachments/assets/d6042b7c-6635-44a4-975f-3ace61bfa10d" />
---

## Formulas (ported from qPANSOPY / qAeroChart `gs_rod_calculator.py`)

**Timing**
```
seconds = (distance_nm / gs_kt) × 3600
→ formatted as MM:SS
```

**Rate of Descent (ft/min)**
```
ROD = floor(gs_kt × gradient_pct × 6068 / 100 / 60)
```

`6068` is the empirically derived NM→ft constant used by ICAO to reproduce published approach chart tables exactly (not the exact 6076.115 ft/NM conversion).

### Verification against published reference values

| GS (KT) | Timing @ 5.2 NM | ROD @ 5.2% | Timing @ 5.2 NM | ROD @ 5.3% |
|---|---|---|---|---|
| 70  | — | — | 4:27 | 375 |
| 80  | 3:54 | 420 | — | — |
| 90  | — | — | 3:28 | 482 |
| 100 | 3:07 | 525 | 3:07 | 536 |
| 120 | 2:36 | 631 | 2:36 | 643 |
| 140 | 2:14 | 736 | 2:14 | 750 |
| 160 | 1:57 | 841 | 1:57 | 857 |
| 180 | 1:44 | 946 | — | — |

All values match the qPANSOPY Python tests and the screenshot provided in the issue.

---

## Changes

### `html/rod_timing.html` *(new)*

Calculator page following the project template pattern:
- Input fieldset: Distance (NM), Gradient (%), Title Row, Footer Row, Timing Label, ROD Label, GS Unit, Timing Unit, GS Values
- Save / Load parameters (JSON)
- "Build Table" button (`id="btnCalcROD"`)
- Results section with live preview table (horizontal scroll for many GS columns) and "Copy to Word" button

### `html/js/rod_timing.js` *(new)*

| Function | Purpose |
|---|---|
| `formatSeconds(total)` | Converts seconds → `MM:SS` string |
| `computeTiming(distanceNM, gsKt)` | Timing formula |
| `computeROD(gsKt, gradientPct)` | ROD formula (floor, 6068 constant) |
| `parseGSValues(raw)` | Parses comma-separated GS string → int[] |
| `buildTable()` | Reads inputs, validates, renders preview, reveals results section |
| `buildPreviewTable(cfg)` | Returns Tailwind-compatible HTML table for browser preview |
| `buildWordHTML(cfg)` | Returns inline-styled HTML table for Word export |
| `copyToWord()` | Calls `copyToClipboard()` from aviation-utils |
| `saveParameters()` / `loadParameters()` | Standard JSON save/load |

Auto-labels when user leaves label fields blank:
- Timing: `FAF-MAPt {distance}NM`
- ROD: `Rate of Descent {gradient}%`

### `html/i18n/en.json`

Added `rod` key section (24 keys).

### `html/i18n/es.json`

Added `rod` key section with Spanish translations.

### `html/Main.html`

Added nav entry `rodButton` under the "Approach & Manoeuvring" section (after MSD Combined).

---

## Testing checklist

- [ ] Distance 5.2 NM, Gradient 5.2%, GS 80,100,120,140,160,180 → timing/ROD match screenshot values
- [ ] Distance 5.2 NM, Gradient 5.3%, GS 70,90,100,120,140,160 → timing/ROD match Python reference values
- [ ] Blank title row → no title row in preview or Word export
- [ ] Custom title "Rate of Descent" → dark blue title row spans all columns
- [ ] Blank footer → no footer row in preview or Word export
- [ ] Custom footer text → italic footer row spans all columns
- [ ] Blank timing label → auto label `FAF-MAPt 5.2NM`
- [ ] Blank ROD label → auto label `Rate of Descent 5.3%`
- [ ] Custom labels → appear in preview and Word table
- [ ] GS Values "80, 100, 120, 140, 160, 180" → 6 GS columns in table
- [ ] Copy to Word → paste into MS Word, table renders correctly
- [ ] Save parameters → JSON includes all 9 inputs
- [ ] Load JSON → all inputs restored, rebuild produces same table
- [ ] Distance missing → toast error (no results shown)
- [ ] Gradient missing / > 30 → toast error
- [ ] Empty or invalid GS values → toast error
- [ ] Dark mode renders correctly
- [ ] Language switch EN ↔ ES updates all labels
- [ ] Sidebar nav entry "GS / Rate of Descent" appears under Approach & Manoeuvring

---

## Files Changed

| File | Change |
|---|---|
| `html/rod_timing.html` | New — calculator page |
| `html/js/rod_timing.js` | New — calculation logic + UI |
| `html/i18n/en.json` | Add `rod` key section |
| `html/i18n/es.json` | Add `rod` key section (Spanish) |
| `html/Main.html` | Add `rodButton` nav entry under Approach & Manoeuvring |
