### PR TITLE
fix/109-rod-placement: GS / Rate of Descent — sidebar placement + rounding option + duplicate guard

### DIFF
--- a/html/Main.html
+++ b/html/Main.html
@@ -894,34 +894,6 @@
                     >
                   </button>
                 </li>
-                <li>
-                  <button
-                    id="rodButton"
-                    data-label="GS / Rate of Descent"
-                    onclick="loadPage('rod_timing.html', this)"
-                    class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
-                  >
-                    <svg
-                      class="text-primary-400 w-5 h-5 mr-3 sidebar-icon"
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      aria-hidden="true"
-                    >
-                      <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-                      <line x1="3" y1="9" x2="21" y2="9"></line>
-                      <line x1="3" y1="15" x2="21" y2="15"></line>
-                      <line x1="9" y1="9" x2="9" y2="21"></line>
-                    </svg>
-                    <span class="sidebar-label" data-i18n="rod.sidebarLabel"
-                      >GS / Rate of Descent</span
-                    >
-                  </button>
-                </li>
                 <li class="sub-section-label" aria-hidden="true">
                   <span data-i18n="sections.subApproach"
                     >Approach &amp; Manoeuvring</span
@@ -1033,6 +1005,34 @@
                     </svg>
                     <span class="sidebar-label" data-i18n="circling.title"
                       >Circling Protection Area</span
+                    >
+                  </button>
+                </li>
+                <li>
+                  <button
+                    id="rodButton"
+                    data-label="GS / Rate of Descent"
+                    onclick="loadPage('rod_timing.html', this)"
+                    class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
+                  >
+                    <svg
+                      class="text-primary-400 w-5 h-5 mr-3 sidebar-icon"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                      <line x1="3" y1="9" x2="21" y2="9"></line>
+                      <line x1="3" y1="15" x2="21" y2="15"></line>
+                      <line x1="9" y1="9" x2="9" y2="21"></line>
+                    </svg>
+                    <span class="sidebar-label" data-i18n="rod.sidebarLabel"
+                      >GS / Rate of Descent</span
                     >
                   </button>
                 </li>

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -303,7 +303,8 @@
     "phGSValues": "e.g. 70, 90, 100, 120, 140, 160",
     "previewTitle": "Preview",
     "buildTable": "Build Table",
-    "addTable": "Add"
+    "addTable": "Add",
+    "roundROD": "Round ROD to nearest 5"
   },
   "windSpiral": {
     "title": "Wind Spiral Calculator"

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -303,7 +303,8 @@
     "phGSValues": "ej. 70, 90, 100, 120, 140, 160",
     "previewTitle": "Vista previa",
     "buildTable": "Construir tabla",
-    "addTable": "Agregar"
+    "addTable": "Agregar",
+    "roundROD": "Redondear ROD al múltiplo de 5 más cercano"
   },
   "windSpiral": {
     "title": "Calculadora de Espiral de Viento"

--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -56,6 +56,7 @@ function createBlockFromInputs() {
   var gsValues   = parseGSValues(document.getElementById("rodGSValues").value);
   var timingLabelInput = document.getElementById("rodTimingLabel").value.trim();
   var rodLabelInput    = document.getElementById("rodRODLabel").value.trim();
+  var round5           = document.getElementById("rodRoundROD").checked;
 
   var timingLabel = timingLabelInput || "FAF-MAPt " + distance + "NM";
   var rodLabel    = rodLabelInput    || "Rate of Descent " + gradient + "%";
@@ -75,7 +76,10 @@ function createBlockFromInputs() {
       {
         label : rodLabel,
         unit  : "ft/min",
-        values: gsValues.map(function (gs) { return String(computeROD(gs, gradient)); })
+        values: gsValues.map(function (gs) {
+          var v = computeROD(gs, gradient);
+          return String(round5 ? Math.round(v / 5) * 5 : v);
+        })
       }
     ]
   };
@@ -91,8 +95,19 @@ function validateInputs() {
   if (isNaN(gradient) || gradient <= 0 || gradient > 30) {
     showToast("Please enter a gradient between 0.1% and 30%.", "error"); return false;
   }
-  if (parseGSValues(document.getElementById("rodGSValues").value).length === 0) {
+  var gsValues = parseGSValues(document.getElementById("rodGSValues").value);
+  if (gsValues.length === 0) {
     showToast("Please enter at least one valid GS value.", "error"); return false;
+  }
+  var seen = {};
+  var dupes = [];
+  gsValues.forEach(function (v) {
+    if (seen[v]) dupes.push(v);
+    else seen[v] = true;
+  });
+  if (dupes.length > 0) {
+    showToast("Duplicate GS value(s): " + dupes.join(", ") + ". Remove duplicates before building.", "error");
+    return false;
   }
   return true;
 }

--- a/html/rod_timing.html
+++ b/html/rod_timing.html
@@ -362,6 +362,14 @@
                 data-i18n-attr="placeholder" data-i18n="rod.phGSValues" placeholder="e.g. 70, 90, 100, 120, 140, 160" />
               <p class="mt-1 text-xs text-gray-400" data-i18n="rod.gsValuesHint">Comma-separated integers (knots)</p>
             </div>
+
+            <div class="flex items-center gap-2 mb-2">
+              <input id="rodRoundROD" type="checkbox"
+                class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 cursor-pointer" />
+              <label for="rodRoundROD"
+                class="text-sm text-gray-600 dark:text-gray-300 cursor-pointer select-none"
+                data-i18n="rod.roundROD">Round ROD to nearest 5</label>
+            </div>
           </fieldset>
 
           <!-- Action buttons -->


### PR DESCRIPTION
# PR — fix/109-rod-placement: GS / Rate of Descent — sidebar placement + rounding option + duplicate guard

## Summary

- **#109** — Moves the **GS / Rate of Descent** sidebar entry from *Departures* to *Approach & Manoeuvring*, directly below *Circling Protection Area*.
- **#110** — Adds a **"Round ROD to nearest 5"** checkbox. When checked, each ROD value is rounded to the closest multiple of 5 (`Math.round(v / 5) * 5`) instead of being floored.
- **#111** — Duplicate GS values are now blocked: Build Table and Add both show an error toast listing the repeated values and refuse to proceed.

## Files Changed

| File | Change |
|---|---|
| `html/Main.html` | Moved `rodButton` `<li>` from Departures to Approach & Manoeuvring (#109) |
| `html/rod_timing.html` | Added `#rodRoundROD` checkbox below GS Values field (#110) |
| `html/js/rod_timing.js` | Nearest-5 rounding in `createBlockFromInputs` (#110); duplicate GS guard in `validateInputs` (#111) |
| `html/i18n/en.json` | Added `rod.roundROD` key (#110) |
| `html/i18n/es.json` | Added `rod.roundROD` key (#110) |

## Testing

### #109
- [ ] Sidebar shows GS / Rate of Descent under Approach & Manoeuvring, below Circling Protection Area
- [ ] Departures section only shows OMNI SID PDG
- [ ] Clicking the entry still loads `rod_timing.html`

### #110
- [ ] Checkbox unchecked → ROD values are floored (original behaviour)
- [ ] Checkbox checked → ROD values rounded to nearest 5 (e.g. 339→340, 396→395, 453→455)
- [ ] "Add" block also respects the checkbox state at time of click
- [ ] Bilingual label displays correctly in EN and ES

### #111
- [ ] `60,70,80,90,100,100,110` → error toast "Duplicate GS value(s): 100…", Build blocked
- [ ] Multiple dupes (e.g. `80,80,100,100`) → toast lists `80, 100`
- [ ] Same check fires on "Add" button
- [ ] No dupes → proceeds normally
