### PR TITLE
feat/112: App-wide font size toggle

### DIFF
--- a/html/Main.html
+++ b/html/Main.html
@@ -1479,6 +1479,20 @@
               </select>
             </div>
 
+            <!-- Font size toggle -->
+            <button
+              id="fontSizeToggle"
+              type="button"
+              aria-label="Toggle font size"
+              title="Toggle font size (Normal / Large)"
+              class="flex items-center justify-center w-8 h-8 rounded-lg text-primary-400 hover:bg-white/10 transition-colors"
+            >
+              <span aria-hidden="true" class="font-bold leading-none select-none"
+                style="font-family:'Barlow',sans-serif">
+                <span style="font-size:0.6rem;opacity:0.7">A</span><span style="font-size:0.9rem">A</span>
+              </span>
+            </button>
+
             <!-- Separator -->
             <span class="w-px h-4 bg-gray-700" aria-hidden="true"></span>
 
@@ -1911,10 +1925,13 @@
           const lang = localStorage.getItem("lang") || "en";
           iframe.onload = function () {
             try {
+              const idoc = iframe.contentDocument || iframe.contentWindow.document;
               if (document.documentElement.classList.contains("dark")) {
-                const idoc =
-                  iframe.contentDocument || iframe.contentWindow.document;
                 idoc?.documentElement?.classList?.add("dark");
+              }
+              const scale = localStorage.getItem("pansops-font-scale");
+              if (idoc?.documentElement) {
+                idoc.documentElement.style.fontSize = (scale === "large") ? "112.5%" : "";
               }
               try {
                 const iw = iframe.contentWindow;
@@ -2005,10 +2022,13 @@
           url.searchParams.set("lang", lang);
           iframe.onload = function () {
             try {
+              const idoc = iframe.contentDocument || iframe.contentWindow.document;
               if (document.documentElement.classList.contains("dark")) {
-                const idoc =
-                  iframe.contentDocument || iframe.contentWindow.document;
                 idoc?.documentElement?.classList?.add("dark");
+              }
+              const scale = localStorage.getItem("pansops-font-scale");
+              if (idoc?.documentElement) {
+                idoc.documentElement.style.fontSize = (scale === "large") ? "112.5%" : "";
               }
               // Force-set language inside the iframe as an extra safeguard
               try {
@@ -2066,6 +2086,26 @@
           if (navigator.vibrate) {
             navigator.vibrate(20);
           }
+        });
+
+        // Font size toggle
+        const fontSizeToggle = document.getElementById("fontSizeToggle");
+        const savedScale = localStorage.getItem("pansops-font-scale");
+        if (savedScale === "large") {
+          html.style.fontSize = "112.5%";
+          fontSizeToggle.classList.add("bg-white/10");
+        }
+        fontSizeToggle.addEventListener("click", function () {
+          const isLarge = html.style.fontSize === "112.5%";
+          const nextSize = isLarge ? "" : "112.5%";
+          html.style.fontSize = nextSize;
+          localStorage.setItem("pansops-font-scale", isLarge ? "normal" : "large");
+          fontSizeToggle.classList.toggle("bg-white/10", !isLarge);
+          try {
+            const idoc = iframe.contentDocument || iframe.contentWindow.document;
+            if (idoc?.documentElement) idoc.documentElement.style.fontSize = nextSize;
+          } catch (e) {}
+          if (navigator.vibrate) navigator.vibrate(15);
         });
 
         // Initialize and handle language changes globally - OPTIMIZED

--- a/html/aviation-utils.js
+++ b/html/aviation-utils.js
@@ -351,4 +351,13 @@ document.addEventListener("DOMContentLoaded", function () {
       attributeFilter: ["class"],
     });
   });
-});
+})();
+
+// ─── Font size preference ─────────────────────────────────────────────────────
+function checkFontSize() {
+  try {
+    var scale = localStorage.getItem("pansops-font-scale");
+    document.documentElement.style.fontSize = (scale === "large") ? "112.5%" : "";
+  } catch (e) {}
+}
+checkFontSize();

--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -140,7 +140,7 @@ function buildBlockElement(block, bi) {
   h += '<tr>';
   h += '<td colspan="' + totalCols + '" contenteditable="true" ' +
     'data-field="title" data-block="' + bi + '" data-ph="Title (leave blank to hide)" ' +
-    'style="background:#0c2240;color:#fff;padding:7px 10px;font-weight:bold;font-size:13px">' +
+    'style="background:#0c2240;color:#fff;padding:7px 10px;font-weight:bold;font-size:0.8125rem">' +
     escapeHtml(block.title) + '</td>';
   h += '</tr>';
 
@@ -228,7 +228,7 @@ function buildBlockElement(block, bi) {
   h += '<tr>';
   h += '<td colspan="' + totalCols + '" contenteditable="true" ' +
     'data-field="footer" data-block="' + bi + '" data-ph="Footer (leave blank to hide)" ' +
-    'style="padding:7px 10px;font-style:italic;color:#94a3b8;font-size:12px">' +
+    'style="padding:7px 10px;font-style:italic;color:#94a3b8;font-size:0.75rem">' +
     escapeHtml(block.footer) + '</td>';
   h += '</tr>';
 

--- a/html/rod_timing.html
+++ b/html/rod_timing.html
@@ -53,7 +53,7 @@
         border-collapse: collapse;
         width: 100%;
         font-family: Calibri, Arial, sans-serif;
-        font-size: 13px;
+        font-size: 0.8125rem;
         border: 2px solid rgba(100, 116, 139, 0.55);
       }
       .rod-table td,
@@ -84,7 +84,7 @@
         justify-content: center;
         width: 22px;
         height: 22px;
-        font-size: 12px;
+        font-size: 0.75rem;
         font-weight: 700;
         border-radius: 4px;
         border: 1px solid #d1d5db;
@@ -148,7 +148,7 @@
       /* ── Add row / col buttons — light mode ──────────── */
       .rod-add-row-btn,
       .rod-add-col-btn {
-        font-size: 11px;
+        font-size: 0.6875rem;
         font-weight: 600;
         padding: 4px 12px;
         border-radius: 5px;
@@ -180,7 +180,7 @@
 
       /* ── Delete block button ──────────────────────────── */
       .rod-del-block-btn {
-        font-size: 11px;
+        font-size: 0.6875rem;
         font-weight: 600;
         padding: 3px 10px;
         border-radius: 4px;


### PR DESCRIPTION
# PR — feat/112: App-wide font size toggle

## Summary

- Adds a **font size toggle button** (`AA`) to the topbar, between the dark mode button and the language selector.
- Two modes: **Normal** (browser default) and **Large** (112.5% root font size, ~18px base).
- Preference persists across sessions via `localStorage` (`pansops-font-scale`).
- Scales all Tailwind `rem`-based sizes proportionally — no per-page overrides needed.
- Applied to both the shell (sidebar, topbar) and every iframe calculator page on load.
<img width="171" height="58" alt="{6FA8B44D-F2A1-4898-9839-EA8B67B9C2B9}" src="https://github.com/user-attachments/assets/05d7944b-ce71-4a64-be44-0cd2bd57f019" />
<img width="1864" height="726" alt="{2C45BFA6-08EE-4DD6-ADEB-E42B3390328F}" src="https://github.com/user-attachments/assets/47ae5b3e-d317-4a69-b6b8-669ae78b1890" />
<img width="1858" height="1043" alt="{44021F9D-FE34-4996-830C-BEACA41251F1}" src="https://github.com/user-attachments/assets/d1044113-2b3f-4fa1-807f-49a2c6418656" />

## Files Changed

| File | Change |
|---|---|
| `html/Main.html` | `AA` toggle button in topbar; init + toggle JS; font size injection in both `iframe.onload` handlers |
| `html/aviation-utils.js` | `checkFontSize()` + auto-call — covers standalone page loads |

## Testing

- [ ] Default state: font size unchanged from current
- [ ] Click `AA` → all text in topbar, sidebar, and iframe content scales up noticeably
- [ ] Button shows active state (subtle background) when large mode is on
- [ ] Refresh page → large size persists
- [ ] Click `AA` again → returns to normal
- [ ] Navigate to a different calculator → new page loads at correct size
- [ ] Dark mode and language toggle still work independently
- [ ] No obvious layout overflow on common calculator pages at large size
