### PR TITLE
fix/113: Rate of Turn — change unit display from °/min to °/s

### DIFF
--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -684,7 +684,7 @@ function copyToWord() {
   const exact = document.getElementById("copyPrecision").dataset.value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
-  var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 60;
+  var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 3600;
 
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
@@ -698,7 +698,7 @@ function copyToWord() {
     "Bank Angle": document.getElementById("bankAngle").value + "\u00b0",
     "Turn Angle A": document.getElementById("outTurnUsed").textContent,
     TAS: fmt(_raw.tas) + " KT",
-    "Rate of turn (R)": fmt(rateOfTurn) + " \u00b0/min",
+    "Rate of turn (R)": fmt(rateOfTurn) + " \u00b0/s",
     "Radius (r)": fmt(_raw.r) + " NM",
     "L1 = r x tan(A/2)": fmt(_raw.L1) + " NM",
     "L2 = 5 x V/3600": fmt(_raw.L2) + " NM",

--- a/html/js/flyover_calculation.js
+++ b/html/js/flyover_calculation.js
@@ -646,8 +646,8 @@ function copyToWord() {
     document.getElementById("copyPrecision").dataset.value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
-  var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 60;
-  var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 60;
+  var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 3600;
+  var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 3600;
 
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
@@ -661,9 +661,9 @@ function copyToWord() {
     "Bank Angle r1": document.getElementById("bankAngle").value + "°",
     "Turn Angle (input)": document.getElementById("turnAngle").value + "°",
     TAS: fmt(_raw.tas) + " KT",
-    "R1": fmt(rateR1) + " °/min",
+    "R1": fmt(rateR1) + " °/s",
     "Turn Angle Used": document.getElementById("outThetaEff").textContent,
-    "R2": fmt(rateR2) + " °/min",
+    "R2": fmt(rateR2) + " °/s",
     "r1 (roll-in)": fmt(_raw.r1) + " NM",
     "r2 (roll-out, 15° fixed)": fmt(_raw.r2) + " NM",
     L1: fmt(_raw.L1) + " NM",


### PR DESCRIPTION
# Plan — fix/113: Rate of Turn — change unit display from °/min to °/s

## Context

Issue #113. The Word export tables in Flyby and Flyover show Rate of Turn in °/min.
Aviation convention is °/s. The UI result panels already display °/s correctly.
msd_calculation.js and rate_turn.js also already use °/s.

## Root cause

Both `copyToWord` functions recalculate Rate of Turn from scratch using:

```js
var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 60;  // → °/min
```

The `/60` converts from °/h to °/min. For °/s the divisor must be `3600`.

## Affected files

| File | Lines | Issue |
|---|---|---|
| `html/js/flyby_calculation.js` | 687, 701 | `/ 60` formula + `°/min` label |
| `html/js/flyover_calculation.js` | 649–650, 664, 666 | `/ 60` formula × 2 + `°/min` labels × 2 |

Already correct (no change needed):
- `html/js/msd_calculation.js` — already uses `°/s`
- `html/js/rate_turn.js` — already uses `°/s`
- `Flyby_Calculation.html` — UI label already `°/s`

## Implementation (1 phase)

### flyby_calculation.js

```js
// Line 687 — was:
var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 60;
// fix:
var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 3600;

// Line 701 — was:
"Rate of turn (R)": fmt(rateOfTurn) + " °/min",
// fix:
"Rate of turn (R)": fmt(rateOfTurn) + " °/s",
```

### flyover_calculation.js

```js
// Lines 649–650 — was:
var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 60;
var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 60;
// fix:
var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 3600;
var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 3600;

// Lines 664, 666 — was:
"R1": fmt(rateR1) + " °/min",
"R2": fmt(rateR2) + " °/min",
// fix:
"R1": fmt(rateR1) + " °/s",
"R2": fmt(rateR2) + " °/s",
```

## Testing

- [ ] Flyby: Copy to Word → Rate of turn shows ~2.16 °/s (not ~129 °/min) for TAS 236 KT, r 1.74 NM
- [ ] Flyover: Copy to Word → R1 and R2 both show °/s values
- [ ] msd_calculation.js: no change, still correct
- [ ] rate_turn.js: no change, still correct
