### PR TITLE
fix/114: MSD — allow turn angle 0° when override is active

### DIFF
--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -355,8 +355,10 @@ function calculateMSD() {
     showToast("WP1: Bank angle must be between 1° and 89°.", "error");
     return;
   }
-  if (isNaN(wp1Turn) || wp1Turn <= 0 || wp1Turn >= 360) {
-    showToast("WP1: Enter a turn angle between 1° and 359°.", "error");
+  var wp1OverrideChecked = wp1Type === "flyby" && document.getElementById("wp1TurnOverride").checked;
+  var wp1TurnMin = wp1OverrideChecked ? 0 : 1;
+  if (isNaN(wp1Turn) || wp1Turn < wp1TurnMin || wp1Turn >= 360) {
+    showToast("WP1: Enter a turn angle between " + wp1TurnMin + "° and 359°.", "error");
     return;
   }
   if (wp2Active) {
@@ -372,8 +374,10 @@ function calculateMSD() {
       showToast("WP2: Bank angle must be between 1° and 89°.", "error");
       return;
     }
-    if (isNaN(wp2Turn) || wp2Turn <= 0 || wp2Turn >= 360) {
-      showToast("WP2: Enter a turn angle between 1° and 359°.", "error");
+    var wp2OverrideChecked = wp2Type === "flyby" && document.getElementById("wp2TurnOverride").checked;
+    var wp2TurnMin = wp2OverrideChecked ? 0 : 1;
+    if (isNaN(wp2Turn) || wp2Turn < wp2TurnMin || wp2Turn >= 360) {
+      showToast("WP2: Enter a turn angle between " + wp2TurnMin + "° and 359°.", "error");
       return;
     }
   }


### PR DESCRIPTION
# PR — fix/114: MSD — allow turn angle 0° when override is active

## Summary

- When the "Override 50° requirement" checkbox is checked in MSD Combined Calculator,
  entering a turn angle of 0° is now allowed for Flyby waypoints.
- Previously the validation rejected `<= 0` unconditionally, before reading the override state.
- Flyover waypoints still require turn angle > 0 (a 0° turn causes division by zero in `sin(θ/2)`).

## Files Changed

| File | Change |
|---|---|
| `html/js/msd_calculation.js` | Read override checkbox before turn-angle validation; allow `>= 0` when override is active |

## Testing

- [ ] WP1 Flyby, override unchecked, turn = 0 → error "between 1° and 359°" (blocked)
- [ ] WP1 Flyby, override checked, turn = 0 → calculation proceeds (M = L2 only)
- [ ] WP1 Flyby, override checked, turn = 1 → proceeds normally
- [ ] WP1 Flyover, turn = 0 → still blocked regardless of override
- [ ] WP2 same cases as WP1
- [ ] Error message shows correct minimum (0 or 1) based on override state
