### PR TITLE
fix/115: Profile Estimator — fix IAF annotation clipping

### DIFF
--- a/html/Profile_Check.html
+++ b/html/Profile_Check.html
@@ -400,6 +400,6 @@
       </div>
     </main>
 
-    <script src="js/profile_check.js"></script>
+    <script src="js/profile_check.js?v=2"></script>
   </body>
 </html>

--- a/html/js/profile_check.js
+++ b/html/js/profile_check.js
@@ -232,12 +232,13 @@ function estimateProfile() {
   // Determine total distance to cover.
   const totalDistance = distToFaf + intermediateLength + initialLength;
   const gridMax = Math.ceil(totalDistance / 5) * 5 || 5;
-  const newSvgWidth = gridMax * xScale + 20;
+  const viewBoxWidth = gridMax * xScale + 100;
 
   // Update the SVG width and viewBox.
   const profileSvg = document.getElementById("profileSvg");
-  profileSvg.setAttribute("width", newSvgWidth);
-  profileSvg.setAttribute("viewBox", `-20 0 ${newSvgWidth} 400`);
+  profileSvg.setAttribute("width", "100%");
+  profileSvg.setAttribute("preserveAspectRatio", "none");
+  profileSvg.setAttribute("viewBox", `-20 0 ${viewBoxWidth} 400`);
 
   // Prepare grid/annotation HTML.
   const isDark = document.documentElement.classList.contains("dark");
@@ -248,7 +249,7 @@ function estimateProfile() {
   gridHtml += `<polygon points="${areaPoints}" fill="${isDark ? "rgba(56,189,248,0.07)" : "rgba(2,132,199,0.08)"}" />`;
 
   // Horizontal datum line.
-  gridHtml += `<line x1="0" y1="${baseY}" x2="${newSvgWidth}" y2="${baseY}" stroke="#94a3b8" class="dark:stroke-slate-500" stroke-width="1" stroke-dasharray="6,3" />`;
+  gridHtml += `<line x1="0" y1="${baseY}" x2="${viewBoxWidth}" y2="${baseY}" stroke="#94a3b8" class="dark:stroke-slate-500" stroke-width="1" stroke-dasharray="6,3" />`;
 
   // Vertical key lines for THR, FAF, IF, IAF.
   const stations = [
@@ -279,7 +280,7 @@ function estimateProfile() {
     }
   }
   // Distance axis label
-  gridHtml += `<text x="${newSvgWidth / 2}" y="${baseY + 32}" font-size="9" font-family="Rajdhani, sans-serif" font-weight="600" text-anchor="middle" fill="#64748b" class="dark:fill-slate-400" letter-spacing="1">NM</text>`;
+  gridHtml += `<text x="${viewBoxWidth / 2}" y="${baseY + 32}" font-size="9" font-family="Rajdhani, sans-serif" font-weight="600" text-anchor="middle" fill="#64748b" class="dark:fill-slate-400" letter-spacing="1">NM</text>`;
 
   // Annotate key profile points with double-ring markers + elevation labels.
   const keyPoints = [


### PR DESCRIPTION
# PR — fix/115: Profile Estimator — fix IAF annotation clipping

## Summary

- Fixes the IAF annotation (waypoint name + elevation label) being clipped at the right edge of the profile SVG diagram.
- Adds 100 px of right-side coordinate margin beyond the last NM grid tick, so the label always has room.
- Replaces pixel-based SVG width (which caused container overflow / horizontal scroll) with `width="100%"` + `preserveAspectRatio="none"`, so the diagram always fills its container.
- Adds `?v=2` to the `<script>` tag to bust stale browser cache.
<img width="1049" height="919" alt="{A5ADEB4C-F921-4405-83FD-E58EAF116A2A}" src="https://github.com/user-attachments/assets/4b2f824e-e56b-4c22-8d3d-cb78dda2eba2" />

## Root cause

`html/js/profile_check.js` computed:
```js
const newSvgWidth = gridMax * xScale + 20;
// viewBox="-20 0 770 400" → visible right boundary = 750 = gridMax * 50
```
The `+20` was entirely consumed by the `-20` viewBox offset, leaving zero actual right margin.  
The IAF annotation rendered at `x + 9` overflowed and was clipped.

## Fix

| File | Change |
|---|---|
| `html/js/profile_check.js` | `viewBoxWidth = gridMax * xScale + 100` (adds 100 px right margin in coordinate space) |
| `html/js/profile_check.js` | `setAttribute("width", "100%")` + `preserveAspectRatio="none"` — SVG fills container, no horizontal scroll |
| `html/Profile_Check.html` | `profile_check.js?v=2` (cache bust) |

`gridMax` formula is unchanged (`Math.ceil(totalDistance / 5) * 5`), so the NM grid still matches the profile tightly.

## Testing

- [ ] Total distance ~12 NM → 15 NM grid, IAF label fully visible with margin
- [ ] Total distance exactly 15 NM → 15 NM grid, IAF label visible (not clipped)
- [ ] Total distance 22 NM → 25 NM grid, IAF label visible
- [ ] Diagram fills container width without horizontal scrollbar in all cases
