### PR TITLE
fix: MSD / Rate of Turn correctness & display consistency

### DIFF
--- a/html/js/flyby_calculation.js
+++ b/html/js/flyby_calculation.js
@@ -37,7 +37,7 @@ if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
   function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
     var radius =
       (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB3));
-    var rateOfTurn = tas / (111.95 * radius);
+    var rateOfTurn = tas / (20 * Math.PI * radius);
     var rateOfTurnCapped = Math.min(rateOfTurn, 3);
     var radiusForCalc =
       rateOfTurnCapped < rateOfTurn
@@ -684,8 +684,6 @@ function copyToWord() {
   const exact = document.getElementById("copyPrecision").dataset.value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
-  var rateOfTurn = (_raw.tas / _raw.r) * (180 / Math.PI) / 60;
-
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
     "Altitude h1":
@@ -698,7 +696,7 @@ function copyToWord() {
     "Bank Angle": document.getElementById("bankAngle").value + "\u00b0",
     "Turn Angle A": document.getElementById("outTurnUsed").textContent,
     TAS: fmt(_raw.tas) + " KT",
-    "Rate of turn (R)": fmt(rateOfTurn) + " \u00b0/min",
+    "Rate of turn (R)": fmt(_raw.rateOfTurn) + " \u00b0/s",
     "Radius (r)": fmt(_raw.r) + " NM",
     "L1 = r x tan(A/2)": fmt(_raw.L1) + " NM",
     "L2 = 5 x V/3600": fmt(_raw.L2) + " NM",

--- a/html/js/flyover_calculation.js
+++ b/html/js/flyover_calculation.js
@@ -37,7 +37,7 @@ if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
   function calculateRadiusWithRateOfTurnCap(tas, bankAngle_deg) {
     var radius =
       (tas * tas) / (68625 * Math.tan(bankAngle_deg * _DEG_TO_RAD_FB2));
-    var rateOfTurn = tas / (111.95 * radius);
+    var rateOfTurn = tas / (20 * Math.PI * radius);
     var rateOfTurnCapped = Math.min(rateOfTurn, 3);
     var radiusForCalc =
       rateOfTurnCapped < rateOfTurn
@@ -646,9 +646,6 @@ function copyToWord() {
     document.getElementById("copyPrecision").dataset.value === "exact";
   const fmt = (v) => (exact ? v.toString() : v.toFixed(4));
 
-  var rateR1 = (_raw.tas / _raw.r1) * (180 / Math.PI) / 60;
-  var rateR2 = (_raw.tas / _raw.r2) * (180 / Math.PI) / 60;
-
   const tableData = {
     IAS: document.getElementById("ias").value + " KT",
     "Altitude h1":
@@ -661,9 +658,9 @@ function copyToWord() {
     "Bank Angle r1": document.getElementById("bankAngle").value + "°",
     "Turn Angle (input)": document.getElementById("turnAngle").value + "°",
     TAS: fmt(_raw.tas) + " KT",
-    "R1": fmt(rateR1) + " °/min",
+    "R1 (rate of turn roll-in)": fmt(_raw.rot1) + " °/s",
     "Turn Angle Used": document.getElementById("outThetaEff").textContent,
-    "R2": fmt(rateR2) + " °/min",
+    "R2 (rate of turn roll-out 15°)": fmt(_raw.rot2) + " °/s",
     "r1 (roll-in)": fmt(_raw.r1) + " NM",
     "r2 (roll-out, 15° fixed)": fmt(_raw.r2) + " NM",
     L1: fmt(_raw.L1) + " NM",

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -27,7 +27,7 @@ if (typeof calculateRadiusWithRateOfTurnCap === "undefined") {
   var calculateRadiusWithRateOfTurnCap = function (tas, bankAngle_deg) {
     var DEG_TO_RAD = Math.PI / 180;
     var radius = (tas * tas) / (68625 * Math.tan(bankAngle_deg * DEG_TO_RAD));
-    var rateOfTurn = tas / (111.95 * radius);
+    var rateOfTurn = tas / (20 * Math.PI * radius);
     var rateOfTurnCapped = Math.min(rateOfTurn, 3);
     var radiusForCalc =
       rateOfTurnCapped < rateOfTurn


### PR DESCRIPTION
# PR — fix: MSD / Rate of Turn correctness & display consistency

## Summary

- **Fix 1 (defensive correctness)**: Corrected wrong constant `111.95` → `20 * Math.PI` in the fallback stubs of flyby, flyover, and MSD calculation files.
- **Fix 2 (display consistency)**: Rate of Turn in Word exports now uses the stored `°/s` value (matching screen display) instead of a freshly computed `°/min` value.

## Root Cause

### Fix 1

The fallback guard `if (typeof calculateRadiusWithRateOfTurnCap === "undefined")` in the three JS files contained `111.95` instead of `20 * Math.PI ≈ 62.83` as the denominator for the rate-of-turn check. This underestimated the rate by 56%, so the 3°/s cap was only triggered at ~5.35°/s actual turn rate — producing a non-conservative (smaller) radius and MSD. The fallback is normally inactive because `aviation-utils.js` is loaded first, but would silently corrupt results if that script ever fails to load.

### Fix 2

`copyToWord` in both standalone flyby and flyover files computed rate of turn independently as `(TAS/r) × (180/π) / 60`, yielding `°/min`, while the on-screen display and MSD combined export show `°/s`. Users comparing screen vs Word doc (or Word doc vs Excel) would see a 60× discrepancy.

## Files Changed

| File                             | Change                                                                                     |
| -------------------------------- | ------------------------------------------------------------------------------------------ |
| `html/js/flyby_calculation.js`   | Fallback stub: `111.95` → `20 * Math.PI`; copyToWord: use `_raw.rateOfTurn` in `°/s`       |
| `html/js/flyover_calculation.js` | Fallback stub: `111.95` → `20 * Math.PI`; copyToWord: use `_raw.rot1`/`_raw.rot2` in `°/s` |
| `html/js/msd_calculation.js`     | Fallback stub: `111.95` → `20 * Math.PI`                                                   |

## Testing

- [ ] Flyby: IAS=180, Alt=8000 ft, ISA=+10, Bank=25°, Turn=90° → Rate ~2.5°/s (< 3, no cap) — screen and Word export should show same value
- [ ] Flyby: IAS=250, Alt=5000 ft, ISA=+15, Bank=30°, Turn=90° → Rate >3°/s (cap active) — verify cap kicks in and MSD uses larger radius
- [ ] Flyover: same cap-active scenario → R1/R2 in Word export now shows `°/s` matching screen
- [ ] No regression on MSD combined calculator
