### PR TITLE
fix/127: MSD result cards alignment when 50° minimum is applied

### DIFF
--- a/html/calculators/msd_calculation.html
+++ b/html/calculators/msd_calculation.html
@@ -737,8 +737,8 @@
             </div>
             <p
               id="out1MinAppliedNote"
-              class="hidden text-xs text-amber-600 dark:text-amber-400 mb-2"
-            ></p>
+              class="invisible text-xs text-amber-600 dark:text-amber-400 mb-2"
+            >&nbsp;</p>
             <div class="grid grid-cols-2 gap-2 text-sm">
               <div
                 class="bg-white dark:bg-gray-800 rounded-lg p-2.5 border border-blue-100 dark:border-blue-900"
@@ -845,7 +845,7 @@
                 class="text-xs font-bold px-2 py-0.5 rounded-full bg-amber-200 dark:bg-amber-800 text-amber-800 dark:text-amber-200"
               ></span>
             </div>
-            <p id="out2MinAppliedNote" class="hidden text-xs text-amber-600 dark:text-amber-400 mb-2"></p>
+            <p id="out2MinAppliedNote" class="invisible text-xs text-amber-600 dark:text-amber-400 mb-2">&nbsp;</p>
             <div id="out2Grid" class="grid grid-cols-2 gap-2 text-sm">
               <div
                 class="bg-white dark:bg-gray-800 rounded-lg p-2.5 border border-amber-100 dark:border-amber-900"

--- a/html/js/msd_calculation.js
+++ b/html/js/msd_calculation.js
@@ -532,9 +532,10 @@ function renderWPResults(n, result, name) {
     minNote.textContent =
       "\u26A0\uFE0F 50\u00B0 minimum applied \u2014 entered " +
       result.inputTurn.toFixed(1) + "\u00B0, using 50\u00B0";
-    minNote.classList.remove("hidden");
+    minNote.classList.remove("invisible");
   } else {
-    minNote.classList.add("hidden");
+    minNote.textContent = "\u00A0";
+    minNote.classList.add("invisible");
   }
 
   document.getElementById(prefix + "L1Cell").classList.remove("hidden");


### PR DESCRIPTION
# PR — fix/127: MSD result cards alignment when 50° minimum is applied

## Summary

- Fixes the vertical misalignment between the WP 1 and WP 2 result columns when the 50° minimum turn angle is applied to one waypoint but not the other.
- The "⚠ 50° minimum applied" note now always reserves its vertical space in both columns, keeping the k Factor / TAS / Radius / L1 / L2 data rows aligned at the same height regardless of which WPs trigger the minimum.
<img width="922" height="870" alt="{DF7A8E50-E96F-410E-BC58-567D6A1A343E}" src="https://github.com/user-attachments/assets/a2dd1316-91c5-4e77-bbc9-b0deb620bcc9" />

## Root Cause

`#out1MinAppliedNote` and `#out2MinAppliedNote` used Tailwind's `hidden` class (`display: none`). When the minimum applied to only one WP, that element was added back to the flow, pushing all grid cells below it down by ~18 px. The other WP column had no such element in flow, so the two columns became visually offset.

## Fix

Replaced `hidden` with `invisible` (`visibility: hidden`) on both note elements. The element stays in the document flow and occupies the same height as the visible note, keeping both columns in sync. A non-breaking space (` `) is set as placeholder content so the `<p>` does not collapse to zero height when invisible.

## Files Changed

| File | Change |
|---|---|
| `html/calculators/msd_calculation.html` | `out1MinAppliedNote`, `out2MinAppliedNote`: `hidden` → `invisible`; added `&nbsp;` as initial content |
| `html/js/msd_calculation.js` | `renderWPResult()`: toggle `invisible` instead of `hidden`; set `" "` as textContent when note is not shown |

## Testing

- [ ] Calculate with both WPs as Flyby, turn angles ≥ 50° — no note visible in either column; rows aligned
- [ ] Calculate with WP 1 turn < 50°, WP 2 turn ≥ 50° — note visible only in WP 1; WP 2 rows stay aligned with WP 1
- [ ] Calculate with WP 2 turn < 50°, WP 1 turn ≥ 50° — note visible only in WP 2; both columns remain aligned
- [ ] Calculate with both WPs turn < 50° — note visible in both columns; rows still aligned
- [ ] Flyover type on either WP — no note shown for that WP; columns stay aligned
- [ ] Override checkbox checked — note not shown even when turn < 50°; alignment preserved
