### PR TITLE
feat/126: FAF Estimator — sortable columns

### DIFF
--- a/html/FAF_Estimator.html
+++ b/html/FAF_Estimator.html
@@ -3,13 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#f9fafb" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)" />
     <title data-i18n="faf.title">FAF Estimator</title>
-    <script src="suppress-tailwind-warn.js"></script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="shared-config.js"></script>
-    <link rel="stylesheet" href="dark-mode.css" />
-    <script src="aviation-utils.js"></script>
-    <script src="i18n/i18n.js"></script>
+    <link rel="stylesheet" href="css/tailwind.css" />
+    <script src="js/shared/shared-config.js" defer></script>
+    <link rel="stylesheet" href="css/dark-mode.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <script src="js/shared/aviation-utils.js" defer></script>
+    <script src="i18n/i18n.js" defer></script>
     <style>
       .faf-table thead th {
         position: sticky;
@@ -72,7 +75,7 @@
               />
               <select
                 id="thrUnit"
-                class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 focus:outline-none dark:text-white"
+                class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 focus:outline-none text-sm text-gray-700 dark:text-white"
                 aria-label="THR unit"
               >
                 <option value="ft" selected data-i18n="common.feet">ft</option>
@@ -100,7 +103,7 @@
               />
               <select
                 id="rdhUnit"
-                class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 focus:outline-none dark:text-white"
+                class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 focus:outline-none text-sm text-gray-700 dark:text-white"
                 aria-label="RDH unit"
               >
                 <option value="m" selected data-i18n="common.meters">m</option>
@@ -166,17 +169,17 @@
       </fieldset>
 
       <!-- Calculate button -->
-      <div class="flex justify-center mb-8">
+      <div class="flex justify-end mt-4">
         <button
           id="btnCalculate"
           type="button"
-          class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-semibold py-3 px-8 rounded-lg shadow transition-colors flex items-center gap-2 text-base"
+          class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-3 px-6 rounded-lg shadow transition-colors flex items-center"
         >
           <svg
             aria-hidden="true"
             focusable="false"
             xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
+            class="h-5 w-5 mr-2"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -184,9 +187,9 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18" />
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
           </svg>
-          <span data-i18n="faf.calculate">Calculate</span>
+          <span data-i18n="common.calculate">Calculate</span>
         </button>
       </div>
 
@@ -253,13 +256,28 @@
         <!-- Table -->
         <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 shadow-sm overflow-hidden">
           <div class="overflow-y-auto max-h-[480px]">
-            <table class="min-w-full faf-table" aria-label="FAF altitude estimation results">
+            <table class="w-full faf-table" aria-label="FAF altitude estimation results">
               <thead class="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
                 <tr>
                   <th scope="col" class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colDist">Dist (NM)</th>
-                  <th scope="col" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colExact">Exact Alt (ft)</th>
-                  <th scope="col" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colRounded">Rounded (ft)</th>
-                  <th scope="col" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colBackVpa">Back VPA (°)</th>
+                  <th scope="col" id="thExact" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-primary-500 dark:hover:text-primary-400 hover:bg-gray-100 dark:hover:bg-gray-600 select-none transition-colors rounded">
+                    <span class="inline-flex items-center justify-end gap-1">
+                      <span data-i18n="faf.colExact">Exact Alt (ft)</span>
+                      <span id="sortIconExact"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 opacity-50" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="4,7 8,3 12,7"/><polyline points="4,9 8,13 12,9"/></svg></span>
+                    </span>
+                  </th>
+                  <th scope="col" id="thRounded" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-primary-500 dark:hover:text-primary-400 hover:bg-gray-100 dark:hover:bg-gray-600 select-none transition-colors rounded">
+                    <span class="inline-flex items-center justify-end gap-1">
+                      <span data-i18n="faf.colRounded">Rounded (ft)</span>
+                      <span id="sortIconRounded"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 opacity-50" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="4,7 8,3 12,7"/><polyline points="4,9 8,13 12,9"/></svg></span>
+                    </span>
+                  </th>
+                  <th scope="col" id="thBackVpa" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-primary-500 dark:hover:text-primary-400 hover:bg-gray-100 dark:hover:bg-gray-600 select-none transition-colors rounded">
+                    <span class="inline-flex items-center justify-end gap-1">
+                      <span data-i18n="faf.colBackVpa">Back VPA (°)</span>
+                      <span id="sortIconBackVpa"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 opacity-50" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="4,7 8,3 12,7"/><polyline points="4,9 8,13 12,9"/></svg></span>
+                    </span>
+                  </th>
                   <th scope="col" class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colUsable">Usable</th>
                 </tr>
               </thead>
@@ -298,6 +316,6 @@
       </section>
     </main>
 
-    <script src="js/faf_estimator.js?v=1"></script>
+    <script src="js/faf_estimator.js" defer></script>
   </body>
 </html>

--- a/html/js/faf_estimator.js
+++ b/html/js/faf_estimator.js
@@ -1,13 +1,8 @@
 document.addEventListener("DOMContentLoaded", function () {
-  try {
-    if (
-      window.parent &&
-      window.parent.document.documentElement.classList.contains("dark")
-    ) {
-      document.documentElement.classList.add("dark");
-    }
-  } catch (e) {
-    console.log("Running in standalone mode");
+  checkDarkMode();
+
+  if (window.I18N) {
+    I18N.init({ defaultLang: "en", supported: ["en", "es"], path: "i18n" }).catch(console.error);
   }
 
   // Auto-fill lower/upper whenever VPA changes
@@ -21,6 +16,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
   document.getElementById("btnCalculate").addEventListener("click", estimateFAF);
   document.getElementById("btnCopy").addEventListener("click", copyToWordDocument);
+
+  _SORT_COLS.forEach(function (entry) {
+    var th = document.getElementById(entry.thId);
+    if (th) th.addEventListener("click", function () { sortBy(entry.col); });
+  });
 
   // Filter pill buttons
   document.getElementById("btnFilterAll").addEventListener("click", function () {
@@ -40,6 +40,13 @@ const FT_TO_M = 0.3048;
 let _rows = [];
 let _params = {};
 let _filter = "all";
+let _sort = { col: null, dir: "asc" };
+
+const _SORT_COLS = [
+  { col: "exactFt",   iconId: "sortIconExact",   thId: "thExact"   },
+  { col: "roundedFt", iconId: "sortIconRounded",  thId: "thRounded" },
+  { col: "backVPA",   iconId: "sortIconBackVpa",  thId: "thBackVpa" },
+];
 
 function toMetres(value, unit) {
   return unit === "m" ? value : value * FT_TO_M;
@@ -101,8 +108,63 @@ function estimateFAF() {
     lower.toFixed(2) + "° – " + upper.toFixed(2) + "°";
 
   _filter = "all";
+  _sort = { col: null, dir: "asc" };
+  updateSortHeaders();
   setFilter("all");
   document.getElementById("resultsSection").classList.remove("hidden");
+}
+
+function sortBy(col) {
+  if (_sort.col === col) {
+    if (_sort.dir === "asc") {
+      _sort.dir = "desc";
+    } else {
+      _sort.col = null;
+      _sort.dir = "asc";
+    }
+  } else {
+    _sort.col = col;
+    _sort.dir = "asc";
+  }
+  updateSortHeaders();
+  renderTable();
+}
+
+function getSortedRows(rows) {
+  if (!_sort.col) return rows;
+  const col = _sort.col;
+  const dir = _sort.dir === "asc" ? 1 : -1;
+  return rows.slice().sort(function (a, b) {
+    return (a[col] - b[col]) * dir;
+  });
+}
+
+function sortIconHtml(state) {
+  if (state === "asc") {
+    return '<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="none" stroke="#38bdf8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3,11 8,4 13,11"/></svg>';
+  }
+  if (state === "desc") {
+    return '<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="none" stroke="#38bdf8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3,5 8,12 13,5"/></svg>';
+  }
+  return '<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 opacity-50" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3,7 8,3 13,7"/><polyline points="3,9 8,13 13,9"/></svg>';
+}
+
+function updateSortHeaders() {
+  _SORT_COLS.forEach(function (entry) {
+    const iconEl = document.getElementById(entry.iconId);
+    const thEl = document.getElementById(entry.thId);
+    if (!iconEl || !thEl) return;
+    const isActive = _sort.col === entry.col;
+    const state = isActive ? _sort.dir : "none";
+    iconEl.innerHTML = sortIconHtml(state);
+    if (isActive) {
+      thEl.classList.add("text-primary-500", "dark:text-primary-400");
+      thEl.classList.remove("text-gray-500", "dark:text-gray-400");
+    } else {
+      thEl.classList.remove("text-primary-500", "dark:text-primary-400");
+      thEl.classList.add("text-gray-500", "dark:text-gray-400");
+    }
+  });
 }
 
 function setFilter(mode) {
@@ -131,12 +193,13 @@ function setFilter(mode) {
 }
 
 function renderTable() {
-  const visible =
+  const filtered =
     _filter === "usable"
       ? _rows.filter((r) => r.usable)
       : _filter === "notUsable"
       ? _rows.filter((r) => !r.usable)
       : _rows;
+  const visible = getSortedRows(filtered);
   const tbody = document.getElementById("fafTableBody");
 
   if (visible.length === 0) {
@@ -152,7 +215,7 @@ function renderTable() {
         : "hover:bg-gray-50 dark:hover:bg-gray-700/50";
       const badge = r.usable
         ? '<span class="inline-block bg-green-100 text-green-800 dark:bg-green-800/60 dark:text-green-200 text-xs font-bold px-2 py-0.5 rounded-full">YES</span>'
-        : '<span class="inline-block bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400 text-xs font-medium px-2 py-0.5 rounded-full">NO</span>';
+        : '<span class="inline-block bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 text-xs font-medium px-2 py-0.5 rounded-full">NO</span>';
       const roundedClass = r.usable
         ? "font-bold text-green-700 dark:text-green-300"
         : "text-gray-700 dark:text-gray-300";


### PR DESCRIPTION
# PR — feat/126: FAF Estimator — sortable columns

## Summary

- Adds sort controls to the **EXACT ALT (FT)**, **ROUNDED (FT)**, and **BACK VPA (°)** column headers of the FAF Altitude Table.
- Clicking a column header cycles through three states: neutral (↕) → ascending (↑) → descending (↓) → neutral.
- Only one column is active at a time; clicking a new column resets the previous one.
- A new calculation resets all sort state back to natural order (by distance).
- **Copy to Word** is unaffected — always exports usable rows in natural distance order.
- Includes a full visual overhaul of `FAF_Estimator.html` to match the app design system.
<img width="716" height="50" alt="{9E6CE893-2BE4-4937-9357-FED12B3F59AD}" src="https://github.com/user-attachments/assets/7b44cde9-1dcc-42d0-bc33-eb0c08d8c5e5" />

## Files Changed

| File | Change |
|---|---|
| `html/js/faf_estimator.js` | Sort logic: `_sort` state, `_SORT_COLS` map, `sortBy()`, `getSortedRows()`, `sortIconHtml()`, `updateSortHeaders()`; `renderTable()` applies sort; `_sort` reset on new calculation; click handlers wired in `DOMContentLoaded`. CSS init: replaced manual dark-mode check with `checkDarkMode()`; added `I18N.init()`. Badge: **NO** restyled to red (`bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300`) for visibility in dark mode. |
| `html/FAF_Estimator.html` | Replaced CDN Tailwind with compiled `css/tailwind.css` + `dark-mode.css`; added deferred `shared-config.js`, `aviation-utils.js`, `i18n.js`. Sortable `<th>` elements: `id`, `cursor-pointer`, hover text + background, `select-none`, neutral sort icon (h-4 w-4). Table: `min-w-full` → `w-full` so columns fill container width. Unit selects (`thrUnit`, `rdhUnit`): added `text-sm text-gray-700` (light-mode text was invisible). Calculate button: right-aligned, waveform icon, `common.calculate` i18n key. |

## Visual changes

| Area | Before | After |
|------|--------|-------|
| Sortable headers | Static text, no affordance | `cursor-pointer`, hover bg, sort icon (↕/↑/↓) |
| Sort icon size | — | h-4 w-4 at 50% opacity neutral / full cyan active |
| "NO" badge | Gray pill (invisible in dark mode) | Red pill (`bg-red-100 / dark:bg-red-900/40`) |
| Table width | Columns auto-sized, blank space on right | `w-full` — fills container, columns distribute proportionally |
| Unit selectors (THR / RDH) | Rendered as tiny colored square (no visible text) | `text-sm text-gray-700` — readable in light and dark mode |
| Calculate button | Centered, table icon | Right-aligned, waveform icon, matches app button pattern |
| CSS source | CDN Tailwind (no custom `primary-*` palette) | Compiled `css/tailwind.css` |

## Interaction Design

| Click | Result |
|-------|--------|
| Neutral column → click | Sorts ascending ↑ (header turns primary blue) |
| Ascending column → click | Sorts descending ↓ |
| Descending column → click | Resets to natural order ↕ (gray) |
| Different column → click | New column sorts ascending; previous resets to neutral |
| Calculate (new run) | All columns reset to neutral, natural order restored |

## Testing

- [ ] Default state after Calculate — all 3 headers show ↕ gray icon; rows in distance order (3.0 → 10.0)
- [ ] Click **EXACT ALT** → rows sorted smallest to largest; ↑ icon in primary blue; other headers neutral
- [ ] Click **EXACT ALT** again → rows sorted largest to smallest; ↓ icon
- [ ] Click **EXACT ALT** again → resets to distance order; ↕ gray
- [ ] Same cycle for **ROUNDED** and **BACK VPA**
- [ ] Click **EXACT ALT** (asc) then click **BACK VPA** → BACK VPA sorts asc; EXACT ALT resets to neutral
- [ ] Sorting + filter: apply "Usable Only" then sort BACK VPA — only usable rows visible, sorted correctly
- [ ] Sort + "Not Usable Only" — non-usable rows sorted correctly
- [ ] Copy to Word after sorting — exported rows still in natural distance order (usable only)
- [ ] Run new calculation while sorted — sort resets to neutral automatically
- [ ] Light mode — THR and RDH unit selectors (m/ft) show readable text
- [ ] Dark mode — active sort header in primary blue; "NO" badge visible in red; "YES" badge visible in green
- [ ] Table fills full container width with no blank space on the right
