### PR TITLE
feat/125: FAF Estimator — per-row copy & filter-aware bulk copy

### DIFF
--- a/html/FAF_Estimator.html
+++ b/html/FAF_Estimator.html
@@ -4,12 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title data-i18n="faf.title">FAF Estimator</title>
-    <script src="suppress-tailwind-warn.js"></script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="shared-config.js"></script>
-    <link rel="stylesheet" href="dark-mode.css" />
-    <script src="aviation-utils.js"></script>
-    <script src="i18n/i18n.js"></script>
+    <link rel="stylesheet" href="css/tailwind.css" />
+    <script src="js/shared/shared-config.js" defer></script>
+    <link rel="stylesheet" href="css/dark-mode.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <script src="js/shared/aviation-utils.js" defer></script>
+    <script src="i18n/i18n.js" defer></script>
     <style>
       .faf-table thead th {
         position: sticky;
@@ -253,7 +254,7 @@
         <!-- Table -->
         <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 shadow-sm overflow-hidden">
           <div class="overflow-y-auto max-h-[480px]">
-            <table class="min-w-full faf-table" aria-label="FAF altitude estimation results">
+            <table class="w-full faf-table" aria-label="FAF altitude estimation results">
               <thead class="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
                 <tr>
                   <th scope="col" class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colDist">Dist (NM)</th>
@@ -261,6 +262,7 @@
                   <th scope="col" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colRounded">Rounded (ft)</th>
                   <th scope="col" class="px-4 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colBackVpa">Back VPA (°)</th>
                   <th scope="col" class="px-4 py-3 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider" data-i18n="faf.colUsable">Usable</th>
+                  <th scope="col" class="w-10 px-3 py-3"></th>
                 </tr>
               </thead>
               <tbody id="fafTableBody" class="divide-y divide-gray-100 dark:divide-gray-700">
@@ -298,6 +300,6 @@
       </section>
     </main>
 
-    <script src="js/faf_estimator.js?v=1"></script>
+    <script src="js/faf_estimator.js" defer></script>
   </body>
 </html>

--- a/html/js/faf_estimator.js
+++ b/html/js/faf_estimator.js
@@ -1,13 +1,8 @@
 document.addEventListener("DOMContentLoaded", function () {
-  try {
-    if (
-      window.parent &&
-      window.parent.document.documentElement.classList.contains("dark")
-    ) {
-      document.documentElement.classList.add("dark");
-    }
-  } catch (e) {
-    console.log("Running in standalone mode");
+  checkDarkMode();
+
+  if (window.I18N) {
+    I18N.init({ defaultLang: "en", supported: ["en", "es"], path: "i18n" }).catch(console.error);
   }
 
   // Auto-fill lower/upper whenever VPA changes
@@ -32,6 +27,7 @@ document.addEventListener("DOMContentLoaded", function () {
   document.getElementById("btnFilterNotUsable").addEventListener("click", function () {
     setFilter("notUsable");
   });
+
 });
 
 const NM_TO_M = 1852;
@@ -152,7 +148,7 @@ function renderTable() {
         : "hover:bg-gray-50 dark:hover:bg-gray-700/50";
       const badge = r.usable
         ? '<span class="inline-block bg-green-100 text-green-800 dark:bg-green-800/60 dark:text-green-200 text-xs font-bold px-2 py-0.5 rounded-full">YES</span>'
-        : '<span class="inline-block bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400 text-xs font-medium px-2 py-0.5 rounded-full">NO</span>';
+        : '<span class="inline-block bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 text-xs font-medium px-2 py-0.5 rounded-full">NO</span>';
       const roundedClass = r.usable
         ? "font-bold text-green-700 dark:text-green-300"
         : "text-gray-700 dark:text-gray-300";
@@ -177,10 +173,74 @@ function renderTable() {
         '<td class="px-4 py-2 text-center">' +
         badge +
         "</td>" +
+        '<td class="px-3 py-2 text-center">' +
+        '<button type="button" onclick="copyRowToWord(' + r.d + ')" ' +
+        'title="Copy row to Word" aria-label="Copy row to Word" ' +
+        'class="inline-flex items-center justify-center w-7 h-7 rounded-md text-gray-400 hover:text-primary-600 hover:bg-primary-50 dark:hover:text-primary-300 dark:hover:bg-primary-900/30 transition-colors">' +
+        '<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+        '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>' +
+        '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>' +
+        '</svg>' +
+        '</button>' +
+        "</td>" +
         "</tr>"
       );
     })
     .join("");
+}
+
+function copyRowToWord(d) {
+  var row = _rows.find(function (r) { return r.d === d; });
+  if (!row) { showToast("Run a calculation first.", "error"); return; }
+
+  const { thrRaw, thrUnit, rdhRaw, rdhUnit, vpa, lower, upper } = _params;
+  const th =
+    "padding:6px 10px;border:1px solid #ccc;background:#0c2240;color:#fff;font-weight:bold;text-align:center;";
+  const td = "padding:6px 10px;border:1px solid #ccc;text-align:right;";
+  const tdc = "padding:6px 10px;border:1px solid #ccc;text-align:center;";
+
+  const inputHtml =
+    '<p style="font-family:Calibri,Arial,sans-serif;font-size:11pt;font-weight:bold;margin:0 0 4px">FAF Estimator — Inputs</p>' +
+    '<table border="1" style="border-collapse:collapse;font-family:Calibri,Arial,sans-serif;font-size:10pt;margin-bottom:14px">' +
+    "<tr><th style=\"" + th + "\">Parameter</th><th style=\"" + th + "\">Value</th></tr>" +
+    "<tr><td style=\"" + tdc + "\">THR Elevation</td><td style=\"" + tdc + "\">" + thrRaw + " " + thrUnit + "</td></tr>" +
+    "<tr><td style=\"" + tdc + "\">RDH</td><td style=\"" + tdc + "\">" + rdhRaw + " " + rdhUnit + "</td></tr>" +
+    "<tr><td style=\"" + tdc + "\">VPA</td><td style=\"" + tdc + "\">" + vpa + "°</td></tr>" +
+    "<tr><td style=\"" + tdc + "\">Lower limit</td><td style=\"" + tdc + "\">" + lower.toFixed(2) + "°</td></tr>" +
+    "<tr><td style=\"" + tdc + "\">Upper limit</td><td style=\"" + tdc + "\">" + upper.toFixed(2) + "°</td></tr>" +
+    "</table>";
+
+  const resultHtml =
+    '<p style="font-family:Calibri,Arial,sans-serif;font-size:11pt;font-weight:bold;margin:0 0 4px">FAF Estimator — Selected Altitude</p>' +
+    '<table border="1" style="border-collapse:collapse;font-family:Calibri,Arial,sans-serif;font-size:10pt">' +
+    "<tr>" +
+    "<th style=\"" + th + "\">Dist (NM)</th>" +
+    "<th style=\"" + th + "\">Exact Alt (ft)</th>" +
+    "<th style=\"" + th + "\">Rounded (ft)</th>" +
+    "<th style=\"" + th + "\">Back VPA (°)</th>" +
+    "<th style=\"" + th + "\">Usable</th>" +
+    "</tr>" +
+    "<tr style=\"background:" + (row.usable ? "#e8f5e9" : "#ffffff") + "\">" +
+    "<td style=\"" + tdc + "\">" + row.d.toFixed(1) + "</td>" +
+    "<td style=\"" + td + "\">" + row.exactFt.toFixed(2) + "</td>" +
+    "<td style=\"" + td + ";font-weight:bold\">" + row.roundedFt + "</td>" +
+    "<td style=\"" + td + "\">" + row.backVPA.toFixed(4) + "</td>" +
+    "<td style=\"" + tdc + "\">" + (row.usable ? "YES" : "NO") + "</td>" +
+    "</tr>" +
+    "</table>";
+
+  const textContent =
+    "FAF Estimator — " + row.d.toFixed(1) + " NM / " + row.roundedFt + " ft (" + (row.usable ? "YES" : "NO") + ")\n" +
+    "THR: " + thrRaw + " " + thrUnit + "  RDH: " + rdhRaw + " " + rdhUnit + "  VPA: " + vpa + "°\n\n" +
+    "Dist(NM)\tExact(ft)\tRounded(ft)\tBack VPA(°)\tUsable\n" +
+    row.d.toFixed(1) + "\t" + row.exactFt.toFixed(2) + "\t" + row.roundedFt + "\t" + row.backVPA.toFixed(4) + "\t" + (row.usable ? "YES" : "NO");
+
+  const blob = new Blob([inputHtml + resultHtml], { type: "text/html" });
+  const textBlob = new Blob([textContent], { type: "text/plain" });
+  navigator.clipboard
+    .write([new ClipboardItem({ "text/html": blob, "text/plain": textBlob })])
+    .then(function () { showToast(row.roundedFt + " ft · " + row.d.toFixed(1) + " NM copied.", "success"); })
+    .catch(function () { showToast("Copy failed. Please try again.", "error"); });
 }
 
 function copyToWordDocument() {
@@ -206,22 +266,27 @@ function copyToWordDocument() {
     "<tr><td style=\"" + tdc + "\">Upper limit</td><td style=\"" + tdc + "\">" + upper.toFixed(2) + "°</td></tr>" +
     "</table>";
 
-  const usableOnly = _rows.filter((r) => r.usable);
-  const resultRows = usableOnly
+  const rowsToExport = _filter === "usable"
+    ? _rows.filter(function (r) { return r.usable; })
+    : _filter === "notUsable"
+    ? _rows.filter(function (r) { return !r.usable; })
+    : _rows;
+  const resultRows = rowsToExport
     .map(
       (r) =>
-        "<tr style=\"background:#e8f5e9\">" +
+        "<tr style=\"background:" + (r.usable ? "#e8f5e9" : "#ffffff") + "\">" +
         "<td style=\"" + tdc + "\">" + r.d.toFixed(1) + "</td>" +
         "<td style=\"" + td + "\">" + r.exactFt.toFixed(2) + "</td>" +
         "<td style=\"" + td + ";font-weight:bold\">" + r.roundedFt + "</td>" +
         "<td style=\"" + td + "\">" + r.backVPA.toFixed(4) + "</td>" +
-        "<td style=\"" + tdc + "\">YES</td>" +
+        "<td style=\"" + tdc + "\">" + (r.usable ? "YES" : "NO") + "</td>" +
         "</tr>"
     )
     .join("");
 
+  const exportLabel = _filter === "usable" ? "Usable Altitudes" : _filter === "notUsable" ? "Not Usable Altitudes" : "All Altitudes";
   const resultHtml =
-    '<p style="font-family:Calibri,Arial,sans-serif;font-size:11pt;font-weight:bold;margin:0 0 4px">FAF Estimator — Usable Altitudes</p>' +
+    '<p style="font-family:Calibri,Arial,sans-serif;font-size:11pt;font-weight:bold;margin:0 0 4px">FAF Estimator — ' + exportLabel + '</p>' +
     '<table border="1" style="border-collapse:collapse;font-family:Calibri,Arial,sans-serif;font-size:10pt">' +
     "<tr>" +
     "<th style=\"" + th + "\">Dist (NM)</th>" +


### PR DESCRIPTION
# PR — feat/125: FAF Estimator — per-row copy & filter-aware bulk copy

## Summary

- Adds a **copy button to every row** in the FAF Altitude Table (usable and not usable) so the user can copy any individual value directly to Word.
- Makes the **"Copy to Word Document"** button filter-aware: it exports exactly what is currently shown — all rows, only usable, or only not usable — instead of always exporting all usable rows.
- Fixes CDN Tailwind → compiled `css/tailwind.css` (same issue as #126, needed on this branch independently).
- Fixes table width (`min-w-full` → `w-full`) so columns fill the container.
- Fixes "NO" badge visibility in dark mode (gray → red pill).
<img width="723" height="362" alt="{42A01738-77DB-4ECA-B0E7-E1A1790B3CEF}" src="https://github.com/user-attachments/assets/f1208abe-dcc8-4738-8627-e0df98dca59e" />

## Files Changed

| File | Change |
|---|---|
| `html/js/faf_estimator.js` | Added `copyRowToWord(d)` for per-row Word export; updated `renderTable()` to add a 6th copy-button TD on every row; updated `copyToWordDocument()` to respect `_filter` (all / usable / notUsable); dynamic export title and row color in Word output |
| `html/FAF_Estimator.html` | Added 6th `<th>` (empty header for copy column); replaced CDN Tailwind with compiled `css/tailwind.css`; fixed script paths and added `defer`; `w-full` on table; red "NO" badge classes |

## Behavior

### Per-row copy button
- Appears in a dedicated last column on **every row** (usable and not usable)
- Click → clipboard receives inputs table + that single row
- Word row background: green (`#e8f5e9`) if usable, white if not usable
- Toast confirms: `"3500 ft · 4.3 NM copied."`

### "Copy to Word Document" (bulk)

| Active filter | Rows exported |
|---|---|
| Show All | All 71 rows (usable green, not usable white) |
| Usable Only | Only usable rows |
| Not Usable Only | Only not-usable rows |

Word document title updates accordingly: "All Altitudes" / "Usable Altitudes" / "Not Usable Altitudes".

## Testing

- [ ] Calculate → all rows visible; every row has a clipboard icon in the last column
- [ ] Click copy button on a usable row → toast "XXXX ft · X.X NM copied."; paste into Word shows inputs + green row with YES
- [ ] Click copy button on a not-usable row → toast shows; Word row is white with NO
- [ ] Filter "Show All" → click "Copy to Word Document" → Word has all 71 rows (usable green, not usable white), title "All Altitudes"
- [ ] Filter "Usable Only" → click "Copy to Word Document" → Word has only usable rows, title "Usable Altitudes"
- [ ] Filter "Not Usable Only" → click "Copy to Word Document" → Word has only not-usable rows, title "Not Usable Altitudes"
- [ ] Dark mode — clipboard icon hover turns primary blue; "NO" badge visible in red
- [ ] Table fills full container width with no blank space on the right
- [ ] Unit selectors (THR / RDH) show readable text in light mode
