### PR TITLE
fix: update font size toggle to scale sidebar only, preserving shell root height

### DIFF
--- a/html/js/main-app.js
+++ b/html/js/main-app.js
@@ -541,18 +541,20 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  // Font size toggle
+  // Font size toggle — scale sidebar + iframe only, never the shell root
+  // (scaling html.style.fontSize shifts the topbar height due to rem units)
   const fontSizeToggle = document.getElementById("fontSizeToggle");
+  const sidebarEl = document.getElementById("sidebar");
   const savedScale = localStorage.getItem("pansops-font-scale");
   if (savedScale === "large") {
-    html.style.fontSize = "112.5%";
+    if (sidebarEl) sidebarEl.style.fontSize = "112.5%";
     fontSizeToggle?.classList.add("bg-white/10");
   }
   if (fontSizeToggle) {
     fontSizeToggle.addEventListener("click", function () {
-      const isLarge = html.style.fontSize === "112.5%";
+      const isLarge = localStorage.getItem("pansops-font-scale") === "large";
       const nextSize = isLarge ? "" : "112.5%";
-      html.style.fontSize = nextSize;
+      if (sidebarEl) sidebarEl.style.fontSize = nextSize;
       localStorage.setItem("pansops-font-scale", isLarge ? "normal" : "large");
       fontSizeToggle.classList.toggle("bg-white/10", !isLarge);
       try {


### PR DESCRIPTION
# PR — feat/112: Font size 

## Summary

- Fixes the layout shift caused by the font size toggle — the topbar no longer changes height when switching between normal and large text.
- Text scaling now applies only to the **sidebar nav** and **calculator content** (iframes), keeping all shell structure (topbar height, button positions) unchanged.

## Root Cause

`html.style.fontSize = "112.5%"` scaled the root element, which made every `rem` unit in the shell grow — including the topbar's `py-2.5` padding and `h-8` icon sizes. This caused the topbar to grow ~5–8px taller and push the iframe content down on every toggle.

## Fix

| Before | After |
|---|---|
| `html.style.fontSize = "112.5%"` (scales entire shell) | `sidebarEl.style.fontSize = "112.5%"` (scales sidebar only) |
| Toggle state read from `html.style.fontSize` | Toggle state read from `localStorage` (reliable, no side effects) |

The iframe content continues to scale via the existing mechanisms:
- **On toggle**: `idoc.documentElement.style.fontSize` (direct apply to current iframe)
- **On iframe load**: `checkFontSize()` in `aviation-utils.js` reads `localStorage` and self-applies

## Files Changed

| File | Change |
|---|---|
| `html/js/main-app.js` | `sidebarEl` replaces `html` as target of font scale; toggle state detection moved to `localStorage` |

## Testing

- [ ] Click font size toggle → topbar height stays the same, no layout shift
- [ ] Calculator content text grows to 112.5% (iframes)
- [ ] Sidebar nav text grows to 112.5%
- [ ] Reload with large size saved → sidebar and calculators still large, topbar unchanged
- [ ] Toggle back to normal → sidebar and calculator text return to base size
- [ ] Both light and dark mode
