### PR TITLE
Fix/111 rod duplicate gs

### DIFF
--- a/html/js/main-app.js
+++ b/html/js/main-app.js
@@ -541,18 +541,20 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  // Font size toggle
+  // Font size toggle — scale sidebar + iframe only, never the shell root
+  // (scaling html.style.fontSize shifts the topbar height due to rem units)
   const fontSizeToggle = document.getElementById("fontSizeToggle");
+  const sidebarEl = document.getElementById("sidebar");
   const savedScale = localStorage.getItem("pansops-font-scale");
   if (savedScale === "large") {
-    html.style.fontSize = "112.5%";
+    if (sidebarEl) sidebarEl.style.fontSize = "112.5%";
     fontSizeToggle?.classList.add("bg-white/10");
   }
   if (fontSizeToggle) {
     fontSizeToggle.addEventListener("click", function () {
-      const isLarge = html.style.fontSize === "112.5%";
+      const isLarge = localStorage.getItem("pansops-font-scale") === "large";
       const nextSize = isLarge ? "" : "112.5%";
-      html.style.fontSize = nextSize;
+      if (sidebarEl) sidebarEl.style.fontSize = nextSize;
       localStorage.setItem("pansops-font-scale", isLarge ? "normal" : "large");
       fontSizeToggle.classList.toggle("bg-white/10", !isLarge);
       try {

--- a/html/js/main-app.js
+++ b/html/js/main-app.js
@@ -541,20 +541,18 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  // Font size toggle — scale sidebar + iframe only, never the shell root
-  // (scaling html.style.fontSize shifts the topbar height due to rem units)
+  // Font size toggle
   const fontSizeToggle = document.getElementById("fontSizeToggle");
-  const sidebarEl = document.getElementById("sidebar");
   const savedScale = localStorage.getItem("pansops-font-scale");
   if (savedScale === "large") {
-    if (sidebarEl) sidebarEl.style.fontSize = "112.5%";
+    html.style.fontSize = "112.5%";
     fontSizeToggle?.classList.add("bg-white/10");
   }
   if (fontSizeToggle) {
     fontSizeToggle.addEventListener("click", function () {
-      const isLarge = localStorage.getItem("pansops-font-scale") === "large";
+      const isLarge = html.style.fontSize === "112.5%";
       const nextSize = isLarge ? "" : "112.5%";
-      if (sidebarEl) sidebarEl.style.fontSize = nextSize;
+      html.style.fontSize = nextSize;
       localStorage.setItem("pansops-font-scale", isLarge ? "normal" : "large");
       fontSizeToggle.classList.toggle("bg-white/10", !isLarge);
       try {

--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -279,6 +279,29 @@ function rbtn(label, onclick, disabled) {
 
 // ─── Cell edit → state sync ───────────────────────────────────────────────────
 function attachCellListeners(container, bi) {
+  // Duplicate-guard for inline GS column header edits
+  container.querySelectorAll("[contenteditable][data-field='gsCol']").forEach(function (el) {
+    el.addEventListener("focus", function () {
+      el.dataset.prevVal = el.textContent.trim();
+    });
+    el.addEventListener("blur", function () {
+      var block = tableBlocks[parseInt(el.dataset.block, 10)];
+      if (!block) return;
+      var ci = parseInt(el.dataset.col, 10);
+      var val = el.textContent.trim();
+      if (val === "") return;
+      var isDupe = block.gsColumns.some(function (v, i) {
+        return i !== ci && v.trim() === val;
+      });
+      if (isDupe) {
+        var prev = el.dataset.prevVal || "";
+        el.textContent = prev;
+        block.gsColumns[ci] = prev;
+        showToast("Duplicate GS value \"" + val + "\". Column reverted.", "error");
+      }
+    });
+  });
+
   container.querySelectorAll("[contenteditable][data-field]").forEach(function (el) {
     el.addEventListener("input", function () {
       var block = tableBlocks[parseInt(el.dataset.block, 10)];


### PR DESCRIPTION
# PR — fix/111: ROD — prevent duplicate GS values via inline edit

## Summary

Closes the remaining gap in duplicate GS value prevention. The form-level validation (Build Table / Add buttons) already blocked duplicates from the input field. This fix adds the same protection for inline editing of GS column headers directly in the table.

## Root Cause

GS column headers in the rendered table are `contenteditable`. The `input` event handler updated `block.gsColumns[ci]` on every keystroke without any duplicate check, allowing a user to rename a column to a value that already existed in another column.

## Fix

Added `focus` + `blur` listeners on `gsCol` contenteditable cells inside `attachCellListeners()`:

- **`focus`**: saves the current value to `el.dataset.prevVal`
- **`blur`**: on leaving the cell, checks whether the typed value already exists in any other column of the same block. If duplicate → reverts the cell text and `block.gsColumns[ci]` to the previous value and shows an error toast

The `input` handler is unchanged — it continues to sync state as the user types. The `blur` guard is the final accept/revert decision point.

## Files Changed

| File | Change |
|---|---|
| `html/js/rod_timing.js` | `focus` + `blur` listeners for `gsCol` cells in `attachCellListeners()` |

## Testing

- [ ] Build Table with `70, 90, 100, 160` → edit column header "90" → type "160" → tab/click away → toast "Duplicate GS value '160'. Column reverted." + cell reverts to "90"
- [ ] Edit "90" → type "95" (no duplicate) → accepted, no toast
- [ ] Multiple duplicate columns (e.g. "70" already exists, try to rename "90" → "70") → reverted
- [ ] Blank column header → allowed without toast
- [ ] Form-level validation still works: type `70, 90, 100, 160, 160` → Build Table → error toast, table not built
