### PR TITLE
fix/110: ROD — rounding checkbox now updates table live

### DIFF
--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -67,6 +67,7 @@ function createBlockFromInputs() {
     gsLabel  : "Ground Speed",
     gsUnit   : gsUnit,
     gsColumns: gsValues.map(String),
+    gradient : gradient,
     rows: [
       {
         label : timingLabel,
@@ -462,6 +463,19 @@ document.addEventListener("DOMContentLoaded", function () {
   document.getElementById("btnCalcROD").addEventListener("click", buildTable);
   document.getElementById("btnAddBlock").addEventListener("click", addBlock);
   document.getElementById("btnCopy").addEventListener("click", copyToWord);
+
+  document.getElementById("rodRoundROD").addEventListener("change", function () {
+    if (tableBlocks.length === 0) return;
+    var isRound = this.checked;
+    tableBlocks.forEach(function (block) {
+      if (block.rows.length < 2) return;
+      block.rows[1].values = block.gsColumns.map(function (gs) {
+        var v = computeROD(parseInt(gs, 10), block.gradient);
+        return String(isRound ? Math.round(v / 5) * 5 : v);
+      });
+    });
+    renderAllBlocks();
+  });
 });
 
 (function () {


### PR DESCRIPTION
## Summary

The "Round ROD to nearest 5" checkbox now updates all existing table blocks immediately when toggled. Previously, the checkbox was only read at Build Table time — changing it after the table was built had no effect.
<img width="1918" height="698" alt="{2C32E2DD-4C8C-4032-9487-B1D759498486}" src="https://github.com/user-attachments/assets/35ef5777-75e0-4d53-8123-a0860cd87b92" />

## Root Cause

`rod_timing.js` had no `change` listener on `#rodRoundROD`. The `round5` flag was only sampled inside `createBlockFromInputs()` at the moment the user clicked Build Table or Add. Additionally, the block state did not store the original `gradient` value, making it impossible to recompute ROD values after the fact.

## Fix

| Change | Location |
|---|---|
| Added `gradient: gradient` to the block object | `createBlockFromInputs()` |
| Added `change` listener on `#rodRoundROD` that recomputes ROD row for all blocks and re-renders | `DOMContentLoaded` |

The listener iterates all `tableBlocks`, rewrites `block.rows[1].values` using the stored `block.gradient` and current `block.gsColumns`, then calls `renderAllBlocks()`. All other edits (labels, title, footer, timing row values) are preserved.

## Files Changed

| File | Change |
|---|---|
| `html/js/rod_timing.js` | `gradient` stored in block; `change` listener on rounding checkbox |

## Testing

- [ ] Build Table (checkbox unchecked) → values unrounded (e.g. 396, 509, 566…)
- [ ] Check "Round ROD to nearest 5" → table updates immediately to nearest 5 (395, 510, 565…)
- [ ] Uncheck → reverts to unrounded values
- [ ] Build Table with checkbox already checked → values rounded from the start
- [ ] Add multiple blocks → checkbox toggle updates all blocks simultaneously
