### PR TITLE
feat/137: Highlight ROD values ≥ 1000 fpm

### DIFF
--- a/html/calculators/rod_timing.html
+++ b/html/calculators/rod_timing.html
@@ -77,6 +77,15 @@
         pointer-events: none;
         font-style: italic;
       }
+      .rod-table td.rod-high-fpm {
+        background: #fef3c7;
+        color: #92400e;
+        font-weight: 600;
+      }
+      .dark .rod-table td.rod-high-fpm {
+        background: rgba(245, 158, 11, 0.25);
+        color: #fbbf24;
+      }
 
       /* ── Control buttons — light mode ───────────────── */
       .rod-cbtn {

--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -19,6 +19,12 @@ function computeROD(gsKt, gradientPct) {
   return Math.floor((gsKt * gradientPct * NM_TO_FT_ROD) / 100 / 60);
 }
 
+// High-ROD flag: values >= 1000 ft/min are highlighted (issue #137)
+function isHighROD(unit, val) {
+  var n = parseFloat(val);
+  return (unit || "").trim().toLowerCase() === "ft/min" && !isNaN(n) && n >= 1000;
+}
+
 // ─── Gradient (%) ↔ VPA (°) conversion ─────────────────────────────────────────
 function pctToVPA(pct) { return Math.atan(pct / 100) * 180 / Math.PI; }
 function vpaToPct(deg) { return Math.tan(deg * Math.PI / 180) * 100; }
@@ -256,8 +262,9 @@ function buildBlockElement(block, bi) {
 
     // values
     row.values.forEach(function (val, ci) {
+      var hiClass = isHighROD(row.unit, val) ? ' class="rod-high-fpm"' : '';
       h += '<td contenteditable="true" data-field="rowVal" data-block="' + bi + '" data-row="' + ri + '" data-col="' + ci + '" ' +
-        'style="padding:7px 10px;text-align:right">' +
+        'style="padding:7px 10px;text-align:right"' + hiClass + '>' +
         escapeHtml(val) + '</td>';
     });
 
@@ -358,7 +365,21 @@ function attachCellListeners(container, bi) {
         case "rowVal":
           block.rows[parseInt(el.dataset.row, 10)].values[parseInt(el.dataset.col, 10)] = val; break;
       }
+      if (el.dataset.field === "rowVal" || el.dataset.field === "rowUnit") {
+        updateRowHighlight(container, parseInt(el.dataset.block, 10), parseInt(el.dataset.row, 10));
+      }
     });
+  });
+}
+
+// Re-toggle the high-ROD highlight on a row's value cells after a live edit
+function updateRowHighlight(container, bi, ri) {
+  var row = tableBlocks[bi].rows[ri];
+  container.querySelectorAll(
+    '[data-field="rowVal"][data-block="' + bi + '"][data-row="' + ri + '"]'
+  ).forEach(function (td) {
+    var ci = parseInt(td.dataset.col, 10);
+    td.classList.toggle("rod-high-fpm", isHighROD(row.unit, row.values[ci]));
   });
 }
 
@@ -445,7 +466,8 @@ function buildWordHTML() {
       rows += '<td style="padding:7px 10px;font-weight:500">' + escapeHtml(row.label) + '</td>';
       rows += '<td style="padding:7px 10px">' + escapeHtml(row.unit) + '</td>';
       row.values.forEach(function (v) {
-        rows += '<td style="padding:7px 10px;text-align:right">' + escapeHtml(v) + '</td>';
+        var hiStyle = isHighROD(row.unit, v) ? ';background:#fde68a;color:#92400e;font-weight:bold' : '';
+        rows += '<td style="padding:7px 10px;text-align:right' + hiStyle + '">' + escapeHtml(v) + '</td>';
       });
       rows += '</tr>';
     });


### PR DESCRIPTION
# PR — feat/137: Highlight ROD values ≥ 1000 fpm

## Summary

In the GS / Rate of Descent Table Builder, rate-of-descent values ≥ 1000 ft/min are operationally undesirable/risky. This highlights those specific cells with an amber background in the preview table, in live edits, and in the "Copy to Word" export.
<img width="894" height="393" alt="{46BD75A7-EBDF-4E2E-859C-0DD738F1C5C5}" src="https://github.com/user-attachments/assets/1348c7c0-db6c-4466-a051-68a7c51485f6" />

## Change

| Change | Location |
|---|---|
| `isHighROD(unit, val)` helper: true when unit is `ft/min` and value ≥ 1000 | `html/js/rod_timing.js` |
| `buildBlockElement()` value cells get `class="rod-high-fpm"` when the helper matches | `html/js/rod_timing.js` |
| `attachCellListeners()` re-toggles `rod-high-fpm` on a row's value cells when a `rowVal`/`rowUnit` cell is edited live, so the highlight stays correct without a full re-render (which would break caret position) | `html/js/rod_timing.js` |
| `buildWordHTML()` appends an inline amber style to matching cells, since the Word export rebuilds its own HTML independently of the on-screen CSS classes | `html/js/rod_timing.js` |
| `.rod-high-fpm` CSS (light + dark variants), following the existing `.rod-table` / `.dark .rod-*` conventions in this file | `html/calculators/rod_timing.html` |

The highlight keys off `row.unit === "ft/min"` rather than a hardcoded row index, so it applies to the ROD row specifically (not the timing row) and generalizes if a row is relabeled or another `ft/min` row is added manually.

## Files Changed

| File | Change |
|---|---|
| `html/js/rod_timing.js` | `isHighROD()` helper; render, live-edit, and Word-export call sites |
| `html/calculators/rod_timing.html` | `.rod-high-fpm` CSS (light + dark) |

## Testing

Verified locally with an automated headless-browser pass against `rod_timing.html`:

- [x] Building a table with ROD ≥ 1000 (distance 5.2 NM, gradient 8%, GS 100-185 kt) highlights only the cells ≥ 1000 (1132, 1294, 1359, 1375, 1415, 1456, 1496); 809 and 970 stay unstyled
- [x] Timing row is never highlighted (different unit)
- [x] Dark mode shows the dark amber variant (`rgba(245, 158, 11, 0.25)` background, `#fbbf24` text)
- [x] Editing a highlighted value cell down below 1000 removes the highlight live, without rebuilding the table
- [x] Editing it back above 1000 restores the highlight live
- [x] Copy to Word HTML includes the inline amber style (`background:#fde68a;color:#92400e;font-weight:bold`) on qualifying cells
- [x] Regression: an all-values-under-1000 table (gradient 3%, GS 60-110 kt) has no highlighted cells
