### PR TITLE
fix: GS / Rate of Descent calculation uses wrong NM→ft constant

### DIFF
--- a/html/js/rod_timing.js
+++ b/html/js/rod_timing.js
@@ -1,5 +1,5 @@
 // ─── Constants ────────────────────────────────────────────────────────────────
-var NM_TO_FT_ROD = 6068.0; // empirically derived for ICAO chart table compatibility
+var NM_TO_FT_ROD = 1852 / 0.3048; // ft per NM (matches aviation-utils.js FT_PER_NM)
 
 // ─── Core formulas ────────────────────────────────────────────────────────────
 function formatSeconds(totalSeconds, unit) {
@@ -16,7 +16,7 @@ function computeTiming(distanceNM, gsKt, unit) {
 }
 
 function computeROD(gsKt, gradientPct) {
-  return Math.floor((gsKt * gradientPct * NM_TO_FT_ROD) / 100 / 60);
+  return Math.round((gsKt * gradientPct * NM_TO_FT_ROD) / 100 / 60);
 }
 
 // ─── Gradient (%) ↔ VPA (°) conversion ─────────────────────────────────────────


### PR DESCRIPTION
# PR — fix: GS / Rate of Descent calculation uses wrong NM→ft constant

## Summary

Corrected the Rate of Descent (ft/min) formula in the GS / Rate of Descent Table Builder, which produced values consistently lower than a manual/Excel calculation for the same inputs. Reported by Antonio Locandro (2026-07-07): distance 5 NM, VPA 3.35°, GS 100-185 kt gave 591/710/828/947/994/1006/1035/1065/1095 in the app vs. 593/711/830/948/996/1008/1037/1067/1097 by hand.

## Root Cause

`computeROD()` in `html/js/rod_timing.js` had two issues:

1. **Wrong NM→ft constant**: `NM_TO_FT_ROD = 6068.0`, used only in this file, instead of the physically defined `1852 / 0.3048 = 6076.1155` ft/NM (1 NM = 1852 m and 1 ft = 0.3048 m are exact conversions, not something to "derive empirically"). Every other calculator in this codebase (`aviation-utils.js`, `msd_calculation.js`, `dme_tolerance.js`, `profile_check.js`) already uses `1852/0.3048`.
2. **`Math.floor()` instead of rounding**: always truncated down, adding further downward bias on top of #1.

The original `docs/pr-96-rod-timing-calculator.md` (this calculator's original build, porting logic from qPANSOPY/qAeroChart) describes `6068` as intentional, claiming it matches "published ICAO chart tables" — no specific table is cited, and it conflicts with every other conversion factor in the app. Antonio's manual Excel calc, using the standard conversion, matches the fix exactly at every tested value; it also matches the *current* app output exactly when using the old constant + floor — strong evidence `6068` was a mistake carried over from the original port, not a deliberate match to a real reference.

## Files Changed

| File | Change |
|---|---|
| `html/js/rod_timing.js` | `NM_TO_FT_ROD`: `6068.0` → `1852/0.3048`; `computeROD()`: `Math.floor` → `Math.round` |

## Testing

Verified end-to-end (headless Edge via Playwright) reproducing the reported example exactly, in both `%` and `VPA (°)` input modes:

| GS (kt) | Before | After | Excel (manual) |
|---|---|---|---|
| 100 | 591 | 593 | 593 |
| 120 | 710 | 711 | 711 |
| 140 | 828 | 830 | 830 |
| 160 | 947 | 948 | 948 |
| 168 | 994 | 996 | 996 |
| 170 | 1006 | 1008 | 1008 |
| 175 | 1035 | 1037 | 1037 |
| 180 | 1065 | 1067 | 1067 |
| 185 | 1095 | 1097 | 1097 |

- [x] % mode: distance 5 NM, gradient 5.853524740912073%, GS list above → exact match to Excel
- [x] VPA mode: distance 5 NM, VPA 3.35°, same GS list → exact match to Excel
- [x] "Round ROD to nearest 5" checkbox still applies correctly on top of the corrected base value
- [x] No regression: GS field's integer-only parsing (`168.7` → `168`) is unchanged, pre-existing by-design behavior (not part of this fix)

## Note (out of scope, found during testing)
`html/js/shared/aviation-utils.js` has a stray `()` after a `document.addEventListener("DOMContentLoaded", ...)` call, throwing a harmless `TypeError` on every calculator page load (the listener itself still registers correctly beforehand). Not touched here — separate issue if the team wants it cleaned up.
