### PR TITLE
feat(#142): copy Profile Diagram along with results table to Word

### DIFF
--- a/html/js/profile_check.js
+++ b/html/js/profile_check.js
@@ -308,8 +308,57 @@ function estimateProfile() {
   document.getElementById("results").classList.remove("hidden");
 }
 
-// Copy inputs and outputs as a formatted HTML table for Word.
-function copyToWordDocument() {
+// Clone #profileSvg, force explicit numeric width/height from its viewBox
+// (a "100%" width doesn't resolve correctly outside document layout), and serialize.
+function serializeProfileSvgForExport(svgElement) {
+  const width =
+    svgElement.viewBox.baseVal.width || svgElement.clientWidth || 520;
+  const height = svgElement.viewBox.baseVal.height || 400;
+  const clone = svgElement.cloneNode(true);
+  clone.setAttribute("width", width);
+  clone.setAttribute("height", height);
+  const markup = new XMLSerializer().serializeToString(clone);
+  return { markup, width, height };
+}
+
+// Rasterize SVG markup to a PNG data URL via an offscreen canvas.
+// scale=2 renders at 2x for crispness when embedded at logical size in Word.
+function svgMarkupToPngDataUrl(markup, width, height, scale = 2) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext("2d");
+      // White background — the diagram's translucent fills are meant to sit
+      // over the app's page background, but Word documents are white.
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL("image/png"));
+    };
+    img.onerror = reject;
+    img.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(markup);
+  });
+}
+
+// Capture the live Profile Diagram as a PNG data URL for clipboard export.
+async function captureProfileDiagramAsPngDataUrl() {
+  const svgElement = document.getElementById("profileSvg");
+  const { markup, width, height } = serializeProfileSvgForExport(svgElement);
+  const dataUrl = await svgMarkupToPngDataUrl(markup, width, height, 2);
+  return { dataUrl, width, height };
+}
+
+// Copy inputs and outputs as a formatted HTML table (plus the profile
+// diagram) for Word.
+async function copyToWordDocument() {
+  if (document.getElementById("results").classList.contains("hidden")) {
+    showToast("Please calculate the profile first.", "error");
+    return;
+  }
+
   const thrElev = document.getElementById("thrElev").value || "N/A";
   const thrElevUnit = document.getElementById("thrElevUnit").value || "N/A";
   const tch = document.getElementById("tch").value || "N/A";
@@ -330,7 +379,7 @@ function copyToWordDocument() {
   const initialElevation =
     document.getElementById("initialElevation").textContent || "N/A";
 
-  const htmlContent = `
+  const tableHtml = `
         <table border="1" style="border-collapse:collapse;width:100%;font-family:Calibri,Arial,sans-serif;font-size:11pt">
           <tr style="background:#0c2240;color:#ffffff"><th style="padding:8px;text-align:left;font-weight:bold">Parameter</th><th style="padding:8px;text-align:left;font-weight:bold">Value</th></tr>
           <tr><td style="padding:8px;text-align:left">THR Elev (ft)</td><td style="padding:8px;text-align:left">${outputThrElev} (Input: ${thrElev} ${thrElevUnit})</td></tr>
@@ -344,9 +393,21 @@ function copyToWordDocument() {
           <tr><td style="padding:8px;text-align:left">Initial Elevation (ft)</td><td style="padding:8px;text-align:left">${initialElevation}</td></tr>
         </table>
       `;
+
+  let diagramHtml = "";
+  try {
+    const { dataUrl, width, height } =
+      await captureProfileDiagramAsPngDataUrl();
+    diagramHtml = `<p style="text-align:center;margin-top:12px"><img src="${dataUrl}" width="${width}" height="${height}" style="max-width:100%" /></p>`;
+  } catch (err) {
+    console.error("Diagram capture failed:", err);
+  }
+
+  const htmlContent = tableHtml + diagramHtml;
   const blob = new Blob([htmlContent], { type: "text/html" });
-  // Plain-text fallback by stripping tags and using tabs/newlines
-  const stripped = htmlContent
+  // Plain-text fallback by stripping tags and using tabs/newlines (table only —
+  // the diagram has no plain-text representation).
+  const stripped = tableHtml
     .replace(/<table[^>]*>/gi, "")
     .replace(/<tr[^>]*>/gi, "")
     .replace(/<th[^>]*>/gi, "")


### PR DESCRIPTION
# PR — feat(#142): copy Profile Diagram along with results table to Word

## Summary

The Profile Estimator's "Copy to Word Document" button now embeds the Profile Diagram (rasterized as a PNG) alongside the existing results table, so pasting into Word shows both together instead of just the table.
<img width="708" height="701" alt="{6DD19459-7BCD-440A-A8B2-8A2360F04E8F}" src="https://github.com/user-attachments/assets/08a27542-e41e-4214-b29e-a258fcd182d9" />

## Root Cause

`copyToWordDocument()` in `profile_check.js` only ever built an HTML `<table>` string and wrote it to the clipboard — the `#profileSvg` diagram element was never referenced anywhere in the copy flow.

## Files Changed

| File | Change |
|---|---|
| `html/js/profile_check.js` | Added `serializeProfileSvgForExport()`, `svgMarkupToPngDataUrl()`, `captureProfileDiagramAsPngDataUrl()` helpers. `copyToWordDocument()` is now `async`, adds a "calculate first" guard clause, rasterizes the diagram to a PNG and embeds it as an `<img>` in the copied HTML, and derives the plain-text clipboard fallback from the table only (avoiding a base64 leak). |

## How it works

1. Clone `#profileSvg`, replacing its `width="100%"` with concrete pixel dimensions read from `viewBox.baseVal` (required — a percentage width doesn't resolve correctly for a detached/standalone SVG).
2. Serialize the clone and load it into an offscreen `<canvas>` (2x scale for crispness, white background fill since the diagram's translucent fills assume the app's page background, not Word's white canvas).
3. Convert to a PNG data URL and embed it as an `<img>` tag appended after the results table in the `text/html` clipboard entry.

## Testing

Verified locally (headless Edge via Playwright) against a local static server:

- [x] Calling the copy handler before clicking "Calculate" shows the toast "Please calculate the profile first." and doesn't write anything malformed to the clipboard.
- [x] After calculating: the `text/html` clipboard entry contains both the `<table>` and an embedded `<img src="data:image/png;base64,...">`.
- [x] The `text/plain` fallback contains only the table text — no base64 data leaked into it.
- [x] Dark mode + a long profile (large distances, `viewBoxWidth` of 3850px): exported image width/height correctly track the dynamic viewBox, with a full (non-truncated) PNG payload — no clipping or distortion.
- [x] No new console errors introduced.

## Not changed (explicit scope decisions)

- No color-normalization pass for dark-mode-only CSS class colors on export — the SVG serializes with its plain attribute fallback values (already light-mode-safe), which was judged sufficient since nothing becomes illegible. Avoids duplicating color logic that already lives inline in `estimateProfile()`.
- No separate `image/png` `ClipboardItem` entry — the embedded `<img>` inside the single `text/html` blob is sufficient for Word's paste behavior.
- No changes to any other calculator's copy handler or to the shared `copyToClipboard()` helper in `aviation-utils.js` — this codebase has no other precedent for copying images to the clipboard, so the capability was added narrowly to Profile Estimator only, per the issue's scope.

## Found but not fixed (out of scope)

- `aviation-utils.js` has a pre-existing stray `()` after a `DOMContentLoaded` listener causing a harmless console error on every page load (previously noted in the ROD calculation fix and #139 PRs).
