### PR TITLE
feat(#136): Distance/Altitude Table calculator

### DIFF
--- a/html/Main.html
+++ b/html/Main.html
@@ -484,6 +484,36 @@
                     >
                   </button>
                 </li>
+                <li>
+                  <button
+                    id="distAltButton"
+                    data-label="Distance/Altitude Calculator"
+                    onclick="loadPage('calculators/dist_alt_calculator.html', this)"
+                    class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
+                  >
+                    <svg
+                      class="text-primary-400 w-5 h-5 mr-3 sidebar-icon"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <polyline points="3 3 3 21 21 21"></polyline>
+                      <polyline
+                        points="7 15 11 15 11 18 15 18 15 11 19 11 19 7"
+                      ></polyline>
+                    </svg>
+                    <span
+                      class="sidebar-label"
+                      data-i18n="distAlt.sidebarLabel"
+                      >Distance/Altitude</span
+                    >
+                  </button>
+                </li>
                 <li class="sub-section-label" aria-hidden="true">
                   <span data-i18n="sections.subPBN">PBN</span>
                 </li>

--- a/html/calculators/dist_alt_calculator.html
+++ b/html/calculators/dist_alt_calculator.html
@@ -1,0 +1,359 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title data-i18n="distAlt.title">Distance/Altitude Calculator</title>
+    <link rel="stylesheet" href="../css/tailwind.css" />
+    <script src="../js/shared/shared-config.js" defer></script>
+    <link rel="stylesheet" href="../css/dark-mode.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <script src="../js/shared/aviation-utils.js" defer></script>
+    <script src="../i18n/i18n.js" defer></script>
+  </head>
+  <body
+    class="bg-gray-50 dark:bg-gray-900 min-h-screen flex items-center justify-center p-4"
+  >
+    <main
+      class="max-w-4xl w-full mx-auto p-6 bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700"
+    >
+      <!-- Header with title and buttons -->
+      <div class="flex flex-wrap justify-between items-center mb-6">
+        <header>
+          <h1
+            class="text-2xl sm:text-3xl font-bold text-primary-700 dark:text-primary-300 flex items-center"
+            data-i18n="distAlt.title"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-7 w-7 sm:h-8 sm:w-8 mr-2"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="3 3 3 21 21 21"></polyline>
+              <polyline points="7 15 11 15 11 18 15 18 15 11 19 11 19 7"></polyline>
+            </svg>
+            Distance/Altitude Calculator
+          </h1>
+        </header>
+        <div class="flex gap-3">
+          <button
+            type="button"
+            id="btnSave"
+            class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-1"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"
+              ></path>
+              <polyline points="17 21 17 13 7 13 7 21"></polyline>
+              <polyline points="7 3 7 8 15 8"></polyline>
+            </svg>
+            <span data-i18n="common.save">Save Parameters</span>
+          </button>
+          <input id="loadFile" type="file" accept=".json" class="hidden" />
+          <button
+            type="button"
+            id="btnLoad"
+            class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-1"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="17 8 12 3 7 8"></polyline>
+              <line x1="12" y1="3" x2="12" y2="15"></line>
+            </svg>
+            <span data-i18n="common.load">Load Parameters</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Inputs -->
+      <fieldset>
+        <legend class="sr-only">Distance/Altitude Parameters</legend>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <div class="space-y-2">
+            <label
+              for="fafAltitude"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="distAlt.fafAltitude"
+              >FAF Altitude</label
+            >
+            <div class="flex gap-2">
+              <input
+                id="fafAltitude"
+                type="number"
+                class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 6000"
+              />
+              <select
+                id="fafAltitudeUnit"
+                class="p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+              >
+                <option value="ft" data-i18n="common.feet">Feet</option>
+                <option value="m" data-i18n="common.meters">Meters</option>
+              </select>
+            </div>
+          </div>
+          <div class="space-y-2">
+            <label
+              for="maptAltitude"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="distAlt.maptAltitude"
+              >MAPt Altitude</label
+            >
+            <div class="flex gap-2">
+              <input
+                id="maptAltitude"
+                type="number"
+                class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 1922"
+              />
+              <select
+                id="maptAltitudeUnit"
+                class="p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+              >
+                <option value="ft" data-i18n="common.feet">Feet</option>
+                <option value="m" data-i18n="common.meters">Meters</option>
+              </select>
+            </div>
+          </div>
+          <div class="space-y-2">
+            <label
+              for="fafMaptDistance"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="distAlt.fafMaptDistance"
+              >FAF - MAPt Distance</label
+            >
+            <div class="flex gap-2">
+              <input
+                id="fafMaptDistance"
+                type="number"
+                step="0.1"
+                class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 12.2"
+              />
+              <span
+                class="p-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-100 dark:bg-gray-700 dark:text-white text-sm font-medium"
+                data-i18n="common.nauticalMiles"
+                >NM</span
+              >
+            </div>
+          </div>
+          <div class="space-y-2">
+            <label
+              for="tchRdh"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="distAlt.tchRdh"
+              >TCH/RDH</label
+            >
+            <div class="flex gap-2">
+              <input
+                id="tchRdh"
+                type="number"
+                class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 49"
+              />
+              <select
+                id="tchRdhUnit"
+                class="p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+              >
+                <option value="ft" data-i18n="common.feet">Feet</option>
+                <option value="m" data-i18n="common.meters">Meters</option>
+              </select>
+            </div>
+          </div>
+          <div class="space-y-2">
+            <label
+              for="oca"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="distAlt.oca"
+              >OCA</label
+            >
+            <div class="flex gap-2">
+              <input
+                id="oca"
+                type="number"
+                class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 2450"
+              />
+              <select
+                id="ocaUnit"
+                class="p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+              >
+                <option value="ft" data-i18n="common.feet">Feet</option>
+                <option value="m" data-i18n="common.meters">Meters</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <!-- Calculate button -->
+      <div class="flex justify-end mt-6">
+        <button
+          type="button"
+          id="btnCalculate"
+          class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-3 px-6 rounded-lg shadow transition-colors flex items-center"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 mr-2"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+          </svg>
+          <span data-i18n="common.calculate">Calculate</span>
+        </button>
+      </div>
+
+      <!-- Results -->
+      <div
+        id="results"
+        role="region"
+        aria-live="polite"
+        aria-atomic="true"
+        class="mt-8 hidden bg-green-50 dark:bg-gray-700 p-6 rounded-xl border border-green-200 dark:border-gray-600"
+      >
+        <h2 class="text-xl font-bold text-green-800 dark:text-green-300 mb-4">
+          <span data-i18n="distAlt.resultsTitle">Distance/Altitude Results</span>
+        </h2>
+
+        <!-- Summary tiles -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-sm text-gray-500 dark:text-gray-400"
+              data-i18n="distAlt.gradientVpa"
+            >
+              Gradient/VPA
+            </p>
+            <p class="text-lg font-semibold dark:text-white">
+              <span id="gradientPct"></span>% (<span id="vpaDeg"></span>°)
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-sm text-gray-500 dark:text-gray-400"
+              data-i18n="distAlt.heightLossPerMile"
+            >
+              Height Loss per Mile
+            </p>
+            <p class="text-lg font-semibold dark:text-white">
+              <span id="heightLossPerMile"></span> ft
+            </p>
+          </div>
+        </div>
+
+        <!-- Distance/Altitude table -->
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="bg-primary-700 text-white">
+                <th class="p-2 text-left" data-i18n="distAlt.tableDistance">
+                  Distance from MAPt (NM)
+                </th>
+                <th
+                  class="p-2 text-left"
+                  data-i18n="distAlt.tableCalculatedAltitude"
+                >
+                  Calculated Altitude (ft)
+                </th>
+                <th
+                  class="p-2 text-left"
+                  data-i18n="distAlt.tablePublicationAltitude"
+                >
+                  Publication Altitude (ft)
+                </th>
+                <th
+                  class="p-2 text-left"
+                  data-i18n="distAlt.tableCalculatedHeight"
+                >
+                  Calculated Height (ft)
+                </th>
+                <th
+                  class="p-2 text-left"
+                  data-i18n="distAlt.tableAdvisoryAltitude"
+                >
+                  Advisory Altitude
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              id="distAltRows"
+              class="divide-y divide-gray-100 dark:divide-gray-700"
+            ></tbody>
+          </table>
+        </div>
+
+        <div class="mt-6 flex justify-end">
+          <button
+            type="button"
+            id="btnCopy"
+            class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-2"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
+              ></path>
+              <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
+            </svg>
+            <span data-i18n="common.copyToWord">Copy to Word Document</span>
+          </button>
+        </div>
+      </div>
+    </main>
+
+    <script src="../js/dist_alt_calculator.js" defer></script>
+  </body>
+</html>

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -330,6 +330,24 @@
     "addTable": "Add",
     "roundROD": "Round ROD to nearest 5"
   },
+  "distAlt": {
+    "title": "Distance/Altitude Calculator",
+    "sidebarLabel": "Distance/Altitude",
+    "resultsTitle": "Distance/Altitude Results",
+    "fafAltitude": "FAF Altitude",
+    "maptAltitude": "MAPt Altitude",
+    "fafMaptDistance": "FAF - MAPt Distance",
+    "tchRdh": "TCH/RDH",
+    "oca": "OCA",
+    "gradientVpa": "Gradient/VPA",
+    "heightLossPerMile": "Height Loss per Mile",
+    "tableDistance": "Distance from MAPt (NM)",
+    "tableCalculatedAltitude": "Calculated Altitude (ft)",
+    "tablePublicationAltitude": "Publication Altitude (ft)",
+    "tableCalculatedHeight": "Calculated Height (ft)",
+    "tableAdvisoryAltitude": "Advisory Altitude",
+    "belowOca": "below OCA"
+  },
   "windSpiral": {
     "title": "Wind Spiral Calculator"
   },

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -330,6 +330,24 @@
     "addTable": "Agregar",
     "roundROD": "Redondear ROD al múltiplo de 5 más cercano"
   },
+  "distAlt": {
+    "title": "Calculadora de Distancia/Altitud",
+    "sidebarLabel": "Distancia/Altitud",
+    "resultsTitle": "Resultados de Distancia/Altitud",
+    "fafAltitude": "Altitud del FAF",
+    "maptAltitude": "Altitud del MAPt",
+    "fafMaptDistance": "Distancia FAF - MAPt",
+    "tchRdh": "TCH/RDH",
+    "oca": "OCA",
+    "gradientVpa": "Gradiente/VPA",
+    "heightLossPerMile": "Pérdida de altura por milla",
+    "tableDistance": "Distancia desde el MAPt (NM)",
+    "tableCalculatedAltitude": "Altitud calculada (ft)",
+    "tablePublicationAltitude": "Altitud de publicación (ft)",
+    "tableCalculatedHeight": "Altura calculada (ft)",
+    "tableAdvisoryAltitude": "Altitud de referencia",
+    "belowOca": "bajo el OCA"
+  },
   "windSpiral": {
     "title": "Calculadora de Espiral de Viento"
   },

--- a/html/js/dist_alt_calculator.js
+++ b/html/js/dist_alt_calculator.js
@@ -1,0 +1,209 @@
+document.addEventListener("DOMContentLoaded", function () {
+  checkDarkMode();
+  initializeUnitSelectors();
+
+  I18N.init({
+    defaultLang: "en",
+    supported: ["en", "es"],
+    path: "i18n",
+  }).catch(console.error);
+
+  document.getElementById("btnSave").addEventListener("click", saveParameters);
+  document.getElementById("btnLoad").addEventListener("click", function () {
+    document.getElementById("loadFile").click();
+  });
+  document
+    .getElementById("loadFile")
+    .addEventListener("change", loadParameters);
+  ["fafAltitudeUnit", "maptAltitudeUnit", "tchRdhUnit", "ocaUnit"].forEach(
+    function (unitId) {
+      const inputId = unitId.replace(/Unit$/, "");
+      document.getElementById(unitId).addEventListener("change", function () {
+        handleUnitChange(inputId, unitId);
+      });
+    },
+  );
+  document
+    .getElementById("btnCalculate")
+    .addEventListener("click", calculateDistAlt);
+  document
+    .getElementById("btnCopy")
+    .addEventListener("click", copyToWordDocument);
+});
+
+function calculateDistAlt() {
+  const fafAltitude = getValueInUnit("fafAltitude", "fafAltitudeUnit", "ft");
+  const maptAltitude = getValueInUnit(
+    "maptAltitude",
+    "maptAltitudeUnit",
+    "ft",
+  );
+  const distanceNM = parseFloat(
+    document.getElementById("fafMaptDistance").value,
+  );
+  const tchRdh = getValueInUnit("tchRdh", "tchRdhUnit", "ft");
+  const oca = getValueInUnit("oca", "ocaUnit", "ft");
+
+  if (
+    isNaN(fafAltitude) ||
+    isNaN(maptAltitude) ||
+    isNaN(distanceNM) ||
+    isNaN(tchRdh) ||
+    isNaN(oca) ||
+    distanceNM <= 0
+  ) {
+    showToast(
+      I18N.get(
+        "messages.enterValid",
+        "Please enter valid values for all inputs.",
+      ),
+      "error",
+    );
+    return;
+  }
+
+  // Gradient (fraction) and VPA (degrees) between FAF and MAPt.
+  const gradient =
+    (fafAltitude - maptAltitude - tchRdh) / (distanceNM * FT_PER_NM);
+  const vpaDeg = Math.atan(gradient) * (180 / Math.PI);
+  const heightLossPerMile = (fafAltitude - maptAltitude - tchRdh) / distanceNM;
+
+  document.getElementById("gradientPct").textContent = (
+    gradient * 100
+  ).toFixed(2);
+  document.getElementById("vpaDeg").textContent = vpaDeg.toFixed(2);
+  document.getElementById("heightLossPerMile").textContent =
+    Math.round(heightLossPerMile);
+
+  // Distance/Altitude table — one row per whole NM from the FAF-MAPt
+  // distance down to the MAPt (0).
+  let rowsHtml = "";
+  for (let d = Math.floor(distanceNM); d >= 0; d--) {
+    const calculatedAltitude =
+      fafAltitude - gradient * (distanceNM - d) * FT_PER_NM;
+    const publicationAltitude = Math.ceil(calculatedAltitude / 10) * 10;
+    const calculatedHeight = publicationAltitude - maptAltitude;
+    const advisoryAltitude =
+      publicationAltitude > oca
+        ? `${d} NM - ${publicationAltitude} (${Math.round(calculatedHeight)})`
+        : I18N.get("distAlt.belowOca", "below OCA");
+
+    rowsHtml += `<tr>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${d} NM</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${calculatedAltitude.toFixed(2)}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${publicationAltitude}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${Math.round(calculatedHeight)}</td>
+      <td class="p-2 text-gray-700 dark:text-gray-300">${advisoryAltitude}</td>
+    </tr>`;
+  }
+  document.getElementById("distAltRows").innerHTML = rowsHtml;
+
+  document.getElementById("results").classList.remove("hidden");
+}
+
+function saveParameters() {
+  const params = {
+    fafAltitude: document.getElementById("fafAltitude").value,
+    fafAltitudeUnit: document.getElementById("fafAltitudeUnit").value,
+    maptAltitude: document.getElementById("maptAltitude").value,
+    maptAltitudeUnit: document.getElementById("maptAltitudeUnit").value,
+    fafMaptDistance: document.getElementById("fafMaptDistance").value,
+    tchRdh: document.getElementById("tchRdh").value,
+    tchRdhUnit: document.getElementById("tchRdhUnit").value,
+    oca: document.getElementById("oca").value,
+    ocaUnit: document.getElementById("ocaUnit").value,
+  };
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${timestamp}_Dist_Alt_Calculation.json`;
+
+  const blob = new Blob([JSON.stringify(params, null, 2)], {
+    type: "application/json",
+  });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+}
+
+function loadParameters(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    try {
+      const data = JSON.parse(e.target.result);
+      document.getElementById("fafAltitude").value = data.fafAltitude || "";
+      document.getElementById("maptAltitude").value = data.maptAltitude || "";
+      document.getElementById("fafMaptDistance").value =
+        data.fafMaptDistance || "";
+      document.getElementById("tchRdh").value = data.tchRdh || "";
+      document.getElementById("oca").value = data.oca || "";
+
+      [
+        ["fafAltitudeUnit", data.fafAltitudeUnit],
+        ["maptAltitudeUnit", data.maptAltitudeUnit],
+        ["tchRdhUnit", data.tchRdhUnit],
+        ["ocaUnit", data.ocaUnit],
+      ].forEach(function ([unitId, value]) {
+        if (value) {
+          const unitSelect = document.getElementById(unitId);
+          unitSelect.dataset.lastUnit = unitSelect.value;
+          unitSelect.value = value;
+        }
+      });
+
+      showToast(
+        I18N.get("messages.saved", "Parameters successfully loaded!"),
+        "success",
+      );
+    } catch (err) {
+      showToast(
+        I18N.get("messages.invalidJson", "Invalid JSON file."),
+        "error",
+      );
+    }
+  };
+  reader.readAsText(file);
+}
+
+function copyToWordDocument() {
+  if (document.getElementById("results").classList.contains("hidden")) {
+    showToast("Please calculate first.", "error");
+    return;
+  }
+
+  const summaryData = {
+    "FAF Altitude": `${document.getElementById("fafAltitude").value} ${document.getElementById("fafAltitudeUnit").value}`,
+    "MAPt Altitude": `${document.getElementById("maptAltitude").value} ${document.getElementById("maptAltitudeUnit").value}`,
+    "FAF - MAPt Distance": `${document.getElementById("fafMaptDistance").value} NM`,
+    "TCH/RDH": `${document.getElementById("tchRdh").value} ${document.getElementById("tchRdhUnit").value}`,
+    OCA: `${document.getElementById("oca").value} ${document.getElementById("ocaUnit").value}`,
+    "Gradient/VPA": `${document.getElementById("gradientPct").textContent}% (${document.getElementById("vpaDeg").textContent}°)`,
+    "Height loss per mile": `${document.getElementById("heightLossPerMile").textContent} ft`,
+  };
+  const summaryHtml = createHTMLTable(
+    summaryData,
+    "Distance/Altitude Parameters",
+  );
+
+  let tableHtml = `
+    <table border="1" style="border-collapse:collapse;width:100%;font-family:Calibri,Arial,sans-serif;font-size:11pt;margin-top:12px">
+      <tr style="background:#0c2240;color:#ffffff">
+        <th style="padding:8px;text-align:left;font-weight:bold">Distance from MAPt (NM)</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Calculated Altitude (ft)</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Publication Altitude (ft)</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Calculated Height (ft)</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Advisory Altitude</th>
+      </tr>
+  `;
+  document.querySelectorAll("#distAltRows tr").forEach((row) => {
+    const cells = row.querySelectorAll("td");
+    tableHtml += `<tr>${Array.from(cells)
+      .map((td) => `<td style="padding:8px;text-align:left">${td.textContent}</td>`)
+      .join("")}</tr>`;
+  });
+  tableHtml += `</table>`;
+
+  copyToClipboard(summaryHtml + tableHtml);
+}

--- a/html/js/main_app.js
+++ b/html/js/main_app.js
@@ -233,6 +233,10 @@ const PAGE_MAP = {
     url: "calculators/bearings_angles.html",
     buttonId: "bearingsAnglesButton",
   },
+  "#dist-alt": {
+    url: "calculators/dist_alt_calculator.html",
+    buttonId: "distAltButton",
+  },
   "#about": { url: "calculators/about.html", buttonId: "aboutButton" },
 };
 // Reverse lookup: url → hash
@@ -260,6 +264,7 @@ const PAGE_TITLES = {
   "calculators/ils_height.html": "ILS Height Calculations",
   "calculators/ils_distance.html": "ILS Distance Calculations",
   "calculators/bearings_angles.html": "Bearings & Angles",
+  "calculators/dist_alt_calculator.html": "Distance/Altitude Calculator",
   "calculators/about.html": "About",
 };
 


### PR DESCRIPTION
# PR — feat(#136): Distance/Altitude Table calculator

## Summary

Adds a new "Distance/Altitude Calculator" to the sidebar (Approach & Manoeuvring section), replicating `Dist_Alt_Calculation.xlsx` — a constant-descent-gradient table publishing stepdown altitude/height advisories between the FAF and the MAPt.

## Root Cause / Motivation

Antonio Locandro was doing this calculation manually in Excel and asked for it to become a web calculator like the rest of the app.

## How it works

Inputs: FAF altitude, MAPt altitude, FAF–MAPt distance, TCH/RDH, OCA (altitude fields have ft/m unit selectors). Calculates:
- Gradient (%) and VPA (°) between FAF and MAPt.
- Height loss per mile (ft).
- A table with one row per whole NM from the FAF–MAPt distance down to 0 (dynamic — not a fixed range), each row showing Calculated Altitude, Publication Altitude (rounded up to the nearest 10 ft), Calculated Height above the MAPt, and an Advisory Altitude string (or "below OCA").

## Files Changed

| File | Change |
|---|---|
| `html/calculators/dist_alt_calculator.html` | New calculator page |
| `html/js/dist_alt_calculator.js` | New calculator logic |
| `html/Main.html` | New sidebar entry under Approach & Manoeuvring |
| `html/js/main_app.js` | `PAGE_MAP`/`PAGE_TITLES` entries for the new page |
| `html/i18n/en.json`, `html/i18n/es.json` | New `distAlt` namespace |

## Testing

Verified locally (headless Edge via Playwright) against a local static server, using the exact sample from the spreadsheet (FAF 6000 ft, MAPt 1922 ft, distance 12.2 NM, TCH 49 ft, OCA 2450 ft):

- [x] Gradient (5.44%), VPA (3.11°), and height loss per mile (330 ft) match the workbook.
- [x] All table rows (12 → 0) match the workbook's cached values exactly for the overlapping range (12–2); the extended rows (1, 0) correctly compute and correctly flip to "below OCA" once Publication Altitude drops under OCA.
- [x] ft/m unit conversion produces identical results regardless of input unit.
- [x] Copy to Word: clipboard contains both the input/summary table and the full distance/altitude table.
- [x] Save/Load parameters round-trips all fields including unit selections.
- [x] Sidebar navigation, topbar breadcrumb, and i18n (English/Spanish) all render correctly.
- [x] No new console errors.

## Not changed / out of scope

- The Excel's approximate ft-per-NM conversion constant (`1852 × 3.2808`) was replaced with this project's existing exact `FT_PER_NM` constant (`1852/0.3048`), consistent with the prior ROD-calculator fix (issue #137). The difference is a thousandth of a foot and disappears after rounding to the nearest 10 ft.
