### PR TITLE
feat: Add Height Loss Calculator and integrate into sidebar navigation

### DIFF
--- a/html/Main.html
+++ b/html/Main.html
@@ -649,6 +649,33 @@
                     >
                   </button>
                 </li>
+                <li>
+                  <button
+                    id="heightLossButton"
+                    data-label="Height Loss Calculator"
+                    onclick="loadPage('calculators/height_loss_calculator.html', this)"
+                    class="sidebar-item w-full flex items-center p-3 text-gray-300 rounded-lg hover:bg-gray-700 group transition-colors"
+                  >
+                    <svg
+                      class="text-primary-400 w-5 h-5 mr-3 sidebar-icon"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M2 12h20M2 12l10-10M2 12l10 10"></path>
+                    </svg>
+                    <span
+                      class="sidebar-label"
+                      data-i18n="heightLoss.sidebarLabel"
+                      >Height Loss</span
+                    >
+                  </button>
+                </li>
               </ul>
 
               <!-- Group separator -->

--- a/html/calculators/height_loss_calculator.html
+++ b/html/calculators/height_loss_calculator.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title data-i18n="heightLoss.title">Height Loss Calculator</title>
+    <link rel="stylesheet" href="../css/tailwind.css" />
+    <script src="../js/shared/shared-config.js" defer></script>
+    <link rel="stylesheet" href="../css/dark-mode.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <script src="../js/shared/aviation-utils.js" defer></script>
+    <script src="../i18n/i18n.js" defer></script>
+  </head>
+  <body
+    class="bg-gray-50 dark:bg-gray-900 min-h-screen flex items-center justify-center p-4"
+  >
+    <main
+      class="max-w-4xl w-full mx-auto p-6 bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-gray-200 dark:border-gray-700"
+    >
+      <!-- Header with title and buttons -->
+      <div class="flex flex-wrap justify-between items-center mb-6">
+        <header>
+          <h1
+            class="text-2xl sm:text-3xl font-bold text-primary-700 dark:text-primary-300 flex items-center"
+            data-i18n="heightLoss.title"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-7 w-7 sm:h-8 sm:w-8 mr-2"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M2 12h20M2 12l10-10M2 12l10 10"></path>
+            </svg>
+            Height Loss Calculator
+          </h1>
+        </header>
+        <div class="flex gap-3">
+          <button
+            type="button"
+            id="btnSave"
+            class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-1"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"
+              ></path>
+              <polyline points="17 21 17 13 7 13 7 21"></polyline>
+              <polyline points="7 3 7 8 15 8"></polyline>
+            </svg>
+            <span data-i18n="common.save">Save Parameters</span>
+          </button>
+          <input id="loadFile" type="file" accept=".json" class="hidden" />
+          <button
+            type="button"
+            id="btnLoad"
+            class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center text-sm"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-1"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="17 8 12 3 7 8"></polyline>
+              <line x1="12" y1="3" x2="12" y2="15"></line>
+            </svg>
+            <span data-i18n="common.load">Load Parameters</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Inputs -->
+      <fieldset>
+        <legend class="sr-only">Height Loss Parameters</legend>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <div class="space-y-2">
+            <label
+              for="adElevation"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="heightLoss.adElevation"
+              >AD Elevation</label
+            >
+            <div
+              class="flex rounded-lg overflow-hidden shadow-sm border border-gray-300 dark:border-gray-600"
+            >
+              <input
+                id="adElevation"
+                type="number"
+                class="flex-grow p-3 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. 1200"
+              />
+              <select
+                id="adElevationUnit"
+                class="bg-gray-100 dark:bg-gray-600 px-3 py-2 border-l border-gray-300 dark:border-gray-600 focus:outline-none dark:text-white"
+              >
+                <option value="m" selected data-i18n="common.meters">m</option>
+                <option value="ft" data-i18n="common.feet">ft</option>
+              </select>
+            </div>
+          </div>
+          <div class="space-y-2">
+            <label
+              for="vpa"
+              class="block font-medium text-gray-700 dark:text-gray-300"
+              data-i18n="heightLoss.vpa"
+              >VPA (°)</label
+            >
+            <input
+              id="vpa"
+              type="number"
+              step="0.1"
+              class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+              placeholder="e.g. 3.5"
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      <!-- Calculate button -->
+      <div class="flex justify-end mt-6">
+        <button
+          type="button"
+          id="btnCalculate"
+          class="bg-primary-600 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-800 text-white font-medium py-3 px-6 rounded-lg shadow transition-colors flex items-center"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 mr-2"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+          </svg>
+          <span data-i18n="common.calculate">Calculate</span>
+        </button>
+      </div>
+
+      <!-- Results -->
+      <div
+        id="results"
+        role="region"
+        aria-live="polite"
+        aria-atomic="true"
+        class="mt-8 hidden bg-green-50 dark:bg-gray-700 p-6 rounded-xl border border-green-200 dark:border-gray-600"
+      >
+        <h2 class="text-xl font-bold text-green-800 dark:text-green-300 mb-4">
+          <span data-i18n="heightLoss.resultsTitle">Height Loss Results</span>
+        </h2>
+
+        <!-- Derived indicator tiles -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-sm text-gray-500 dark:text-gray-400"
+              data-i18n="heightLoss.elevAdjustmentRequired"
+            >
+              Adjustment due to Elevation Required
+            </p>
+            <p class="text-lg font-semibold dark:text-white">
+              <span id="elevAdjustmentRequired"></span>
+            </p>
+          </div>
+          <div
+            class="bg-white dark:bg-gray-800 p-3 rounded-lg border border-green-100 dark:border-gray-600 shadow-sm"
+          >
+            <p
+              class="text-sm text-gray-500 dark:text-gray-400"
+              data-i18n="heightLoss.vpaAdjustmentRequired"
+            >
+              Adjustment due to VPA Required
+            </p>
+            <p class="text-lg font-semibold dark:text-white">
+              <span id="vpaAdjustmentRequired"></span>
+            </p>
+          </div>
+        </div>
+
+        <!-- Results unit selector -->
+        <div class="flex items-center gap-3 mb-4">
+          <label
+            for="resultsUnit"
+            class="font-medium text-gray-700 dark:text-gray-300 text-sm"
+            data-i18n="heightLoss.resultsUnit"
+            >Results Unit</label
+          >
+          <select
+            id="resultsUnit"
+            class="p-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:text-white text-sm"
+          >
+            <option value="m" data-i18n="common.meters">m</option>
+            <option value="ft" data-i18n="common.feet">ft</option>
+          </select>
+        </div>
+
+        <!-- Height loss table -->
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="bg-primary-700 text-white">
+                <th class="p-2 text-left" data-i18n="heightLoss.category">
+                  Category
+                </th>
+                <th class="p-2 text-left" data-i18n="heightLoss.vat">
+                  Vat (kt)
+                </th>
+                <th class="p-2 text-left" data-i18n="heightLoss.radioAlt">
+                  Radio Altimeter
+                </th>
+                <th class="p-2 text-left" data-i18n="heightLoss.pressureAlt">
+                  Pressure Altimeter
+                </th>
+                <th class="p-2 text-left" data-i18n="heightLoss.adjElev">
+                  Adjustment due to Elevation
+                </th>
+                <th class="p-2 text-left" data-i18n="heightLoss.adjVpa">
+                  Adjustment due to VPA
+                </th>
+                <th
+                  class="p-2 text-left"
+                  data-i18n="heightLoss.adjustedHeightLoss"
+                >
+                  Adjusted Height Loss
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              id="heightLossRows"
+              class="divide-y divide-gray-100 dark:divide-gray-700"
+            ></tbody>
+          </table>
+        </div>
+
+        <div class="mt-6 flex justify-end">
+          <button
+            type="button"
+            id="btnCopy"
+            class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white font-medium py-2 px-4 rounded-lg shadow transition-colors flex items-center"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 mr-2"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
+              ></path>
+              <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
+            </svg>
+            <span data-i18n="common.copyToWord">Copy to Word Document</span>
+          </button>
+        </div>
+      </div>
+    </main>
+
+    <script src="../js/height_loss_calculator.js" defer></script>
+  </body>
+</html>

--- a/html/i18n/en.json
+++ b/html/i18n/en.json
@@ -21,7 +21,9 @@
     "nauticalMiles": "NM",
     "celsius": "°C",
     "copyRounded": "Rounded (4 dec.)",
-    "copyExact": "Exact"
+    "copyExact": "Exact",
+    "yes": "Yes",
+    "no": "No"
   },
   "rateTurn": {
     "title": "Rate & Radius of Turn",
@@ -96,6 +98,23 @@
     "methodA": "Right Angle Computation FAP Altitude",
     "methodB": "Considering Earth Curvature FAP Altitude",
     "rdhAdjustment": "RDH >15m Adjustment"
+  },
+  "heightLoss": {
+    "title": "Height Loss Calculator",
+    "sidebarLabel": "Height Loss",
+    "resultsTitle": "Height Loss Results",
+    "adElevation": "AD Elevation",
+    "vpa": "VPA",
+    "elevAdjustmentRequired": "Adjustment due to Elevation Required",
+    "vpaAdjustmentRequired": "Adjustment due to VPA Required",
+    "resultsUnit": "Results Unit",
+    "category": "Category",
+    "vat": "Vat (kt)",
+    "radioAlt": "Radio Altimeter",
+    "pressureAlt": "Pressure Altimeter",
+    "adjElev": "Adjustment due to Elevation",
+    "adjVpa": "Adjustment due to VPA",
+    "adjustedHeightLoss": "Adjusted Height Loss"
   },
   "bearings": {
     "title": "Bearings Angles",

--- a/html/i18n/es.json
+++ b/html/i18n/es.json
@@ -21,7 +21,9 @@
     "nauticalMiles": "NM",
     "celsius": "°C",
     "copyRounded": "Redondeado (4 dec.)",
-    "copyExact": "Exacto"
+    "copyExact": "Exacto",
+    "yes": "Sí",
+    "no": "No"
   },
   "rateTurn": {
     "title": "Tasa y Radio de Giro",
@@ -96,6 +98,23 @@
     "methodA": "Altitud FAP por triángulo rectángulo",
     "methodB": "Altitud FAP considerando curvatura terrestre",
     "rdhAdjustment": "Ajuste RDH >15m"
+  },
+  "heightLoss": {
+    "title": "Calculadora de Pérdida de Altura",
+    "sidebarLabel": "Pérdida de Altura",
+    "resultsTitle": "Resultados de Pérdida de Altura",
+    "adElevation": "Elevación del Aeródromo",
+    "vpa": "VPA",
+    "elevAdjustmentRequired": "Ajuste por Elevación Requerido",
+    "vpaAdjustmentRequired": "Ajuste por VPA Requerido",
+    "resultsUnit": "Unidad de Resultados",
+    "category": "Categoría",
+    "vat": "Vat (kt)",
+    "radioAlt": "Radioaltímetro",
+    "pressureAlt": "Altímetro de Presión",
+    "adjElev": "Ajuste por Elevación",
+    "adjVpa": "Ajuste por VPA",
+    "adjustedHeightLoss": "Pérdida de Altura Ajustada"
   },
   "bearings": {
     "title": "Ángulos y Rumbos",

--- a/html/js/height_loss_calculator.js
+++ b/html/js/height_loss_calculator.js
@@ -1,0 +1,217 @@
+// Fixed reference table (matches the source workbook's hardcoded Vat per
+// aircraft category — not user-editable).
+const CATEGORIES = [
+  { id: "A", vat: 90 },
+  { id: "B", vat: 120 },
+  { id: "C", vat: 140 },
+  { id: "D", vat: 165 },
+];
+
+// Last computed rows in meters, so switching the Results Unit selector
+// re-renders from the source values instead of round-tripping displayed ones.
+let lastComputedRows = null;
+let lastIndicators = null;
+
+document.addEventListener("DOMContentLoaded", function () {
+  checkDarkMode();
+  initializeUnitSelectors();
+
+  I18N.init({
+    defaultLang: "en",
+    supported: ["en", "es"],
+    path: "i18n",
+  }).catch(console.error);
+
+  document.getElementById("btnSave").addEventListener("click", saveParameters);
+  document.getElementById("btnLoad").addEventListener("click", function () {
+    document.getElementById("loadFile").click();
+  });
+  document
+    .getElementById("loadFile")
+    .addEventListener("change", loadParameters);
+  document
+    .getElementById("adElevationUnit")
+    .addEventListener("change", function () {
+      handleUnitChange("adElevation", "adElevationUnit");
+    });
+  document
+    .getElementById("btnCalculate")
+    .addEventListener("click", calculateHeightLoss);
+  document
+    .getElementById("resultsUnit")
+    .addEventListener("change", renderHeightLossTable);
+  document
+    .getElementById("btnCopy")
+    .addEventListener("click", copyToWordDocument);
+});
+
+function calculateHeightLoss() {
+  const elevationM = getValueInUnit("adElevation", "adElevationUnit", "m");
+  const vpaDeg = parseFloat(document.getElementById("vpa").value);
+
+  if (isNaN(elevationM) || isNaN(vpaDeg)) {
+    showToast(
+      I18N.get(
+        "messages.enterValid",
+        "Please enter valid values for all inputs.",
+      ),
+      "error",
+    );
+    return;
+  }
+
+  const elevAdjustmentRequired = elevationM > 900;
+  const vpaAdjustmentRequired = vpaDeg > 3.2;
+
+  document.getElementById("elevAdjustmentRequired").textContent =
+    elevAdjustmentRequired
+      ? I18N.get("common.yes", "Yes")
+      : I18N.get("common.no", "No");
+  document.getElementById("vpaAdjustmentRequired").textContent =
+    vpaAdjustmentRequired
+      ? I18N.get("common.yes", "Yes")
+      : I18N.get("common.no", "No");
+  lastIndicators = { elevAdjustmentRequired, vpaAdjustmentRequired };
+
+  lastComputedRows = CATEGORIES.map(function (cat) {
+    const radioAltM = 0.177 * cat.vat - 3.2;
+    const pressureAltM = 0.125 * cat.vat + 28.3;
+    const adjElevM = elevAdjustmentRequired
+      ? 0.02 * (elevationM / 300) * radioAltM
+      : 0;
+    const adjVpaM = vpaAdjustmentRequired
+      ? 0.05 * ((vpaDeg - 3.2) / 0.1) * radioAltM
+      : 0;
+    const adjustedHeightLossM = pressureAltM + adjElevM + adjVpaM;
+
+    return {
+      category: cat.id,
+      vat: cat.vat,
+      radioAltM,
+      pressureAltM,
+      adjElevM,
+      adjVpaM,
+      adjustedHeightLossM,
+    };
+  });
+
+  renderHeightLossTable();
+  document.getElementById("results").classList.remove("hidden");
+}
+
+function renderHeightLossTable() {
+  if (!lastComputedRows) return;
+
+  const unit = document.getElementById("resultsUnit").value;
+  const convert = (m) => (unit === "ft" ? metersToFeet(m) : m);
+
+  let rowsHtml = "";
+  lastComputedRows.forEach(function (row) {
+    rowsHtml += `<tr>
+      <td class="p-2 text-gray-700 dark:text-gray-300">${row.category}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${row.vat}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${convert(row.radioAltM).toFixed(2)}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${convert(row.pressureAltM).toFixed(2)}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${convert(row.adjElevM).toFixed(2)}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${convert(row.adjVpaM).toFixed(2)}</td>
+      <td class="p-2 tabular-nums text-gray-700 dark:text-gray-300">${convert(row.adjustedHeightLossM).toFixed(2)}</td>
+    </tr>`;
+  });
+  document.getElementById("heightLossRows").innerHTML = rowsHtml;
+}
+
+function saveParameters() {
+  const params = {
+    adElevation: document.getElementById("adElevation").value,
+    adElevationUnit: document.getElementById("adElevationUnit").value,
+    vpa: document.getElementById("vpa").value,
+    resultsUnit: document.getElementById("resultsUnit").value,
+  };
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${timestamp}_Height_Loss_Calculation.json`;
+
+  const blob = new Blob([JSON.stringify(params, null, 2)], {
+    type: "application/json",
+  });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+}
+
+function loadParameters(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    try {
+      const data = JSON.parse(e.target.result);
+      document.getElementById("adElevation").value = data.adElevation || "";
+      document.getElementById("vpa").value = data.vpa || "";
+
+      if (data.adElevationUnit) {
+        const unitSelect = document.getElementById("adElevationUnit");
+        unitSelect.dataset.lastUnit = unitSelect.value;
+        unitSelect.value = data.adElevationUnit;
+      }
+      if (data.resultsUnit) {
+        document.getElementById("resultsUnit").value = data.resultsUnit;
+      }
+
+      showToast(
+        I18N.get("messages.saved", "Parameters successfully loaded!"),
+        "success",
+      );
+    } catch (err) {
+      showToast(
+        I18N.get("messages.invalidJson", "Invalid JSON file."),
+        "error",
+      );
+    }
+  };
+  reader.readAsText(file);
+}
+
+function copyToWordDocument() {
+  if (document.getElementById("results").classList.contains("hidden")) {
+    showToast("Please calculate first.", "error");
+    return;
+  }
+
+  const unit = document.getElementById("resultsUnit").value;
+  const summaryData = {
+    "AD Elevation": `${document.getElementById("adElevation").value} ${document.getElementById("adElevationUnit").value}`,
+    VPA: `${document.getElementById("vpa").value}°`,
+    "Adjustment due to Elevation Required": document.getElementById(
+      "elevAdjustmentRequired",
+    ).textContent,
+    "Adjustment due to VPA Required": document.getElementById(
+      "vpaAdjustmentRequired",
+    ).textContent,
+  };
+  const summaryHtml = createHTMLTable(summaryData, "Height Loss Parameters");
+
+  const unitLabel = unit === "ft" ? "ft" : "m";
+  let tableHtml = `
+    <table border="1" style="border-collapse:collapse;width:100%;font-family:Calibri,Arial,sans-serif;font-size:11pt;margin-top:12px">
+      <tr style="background:#0c2240;color:#ffffff">
+        <th style="padding:8px;text-align:left;font-weight:bold">Category</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Vat (kt)</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Radio Altimeter (${unitLabel})</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Pressure Altimeter (${unitLabel})</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Adjustment due to Elevation (${unitLabel})</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Adjustment due to VPA (${unitLabel})</th>
+        <th style="padding:8px;text-align:left;font-weight:bold">Adjusted Height Loss (${unitLabel})</th>
+      </tr>
+  `;
+  document.querySelectorAll("#heightLossRows tr").forEach((row) => {
+    const cells = row.querySelectorAll("td");
+    tableHtml += `<tr>${Array.from(cells)
+      .map((td) => `<td style="padding:8px;text-align:left">${td.textContent}</td>`)
+      .join("")}</tr>`;
+  });
+  tableHtml += `</table>`;
+
+  copyToClipboard(summaryHtml + tableHtml);
+}

--- a/html/js/main_app.js
+++ b/html/js/main_app.js
@@ -233,6 +233,10 @@ const PAGE_MAP = {
     url: "calculators/bearings_angles.html",
     buttonId: "bearingsAnglesButton",
   },
+  "#height-loss": {
+    url: "calculators/height_loss_calculator.html",
+    buttonId: "heightLossButton",
+  },
   "#about": { url: "calculators/about.html", buttonId: "aboutButton" },
 };
 // Reverse lookup: url → hash
@@ -260,6 +264,7 @@ const PAGE_TITLES = {
   "calculators/ils_height.html": "ILS Height Calculations",
   "calculators/ils_distance.html": "ILS Distance Calculations",
   "calculators/bearings_angles.html": "Bearings & Angles",
+  "calculators/height_loss_calculator.html": "Height Loss Calculator",
   "calculators/about.html": "About",
 };
 


### PR DESCRIPTION
# PR — feat(#143): Height Loss Calculator

## Summary

Adds a new "Height Loss Calculator" to the sidebar's **ILS** section, replicating `HeightLoss_Calculation.xlsx` — computes altimeter height-loss margins (Radio/Pressure Altimeter, plus elevation- and VPA-driven adjustments) for aircraft categories A–D.

## Root Cause / Motivation

Antonio Locandro was doing this calculation manually in Excel and asked for it to become a web calculator under the ILS tab. He specifically flagged that the spreadsheet assumes AD elevation in meters, but the web app should support both meters and feet — for the input and the results.

## How it works

Inputs: AD elevation (ft/m selector), VPA (degrees). Calculates:
- Two Yes/No indicators: whether an elevation adjustment (elevation > 900 m) and/or a VPA adjustment (VPA > 3.2°) apply.
- A fixed 4-row table (categories A/B/C/D, each with a standard reference Vat) showing Radio Altimeter, Pressure Altimeter, Adjustment due to Elevation, Adjustment due to VPA, and Adjusted Height Loss — all convertible between meters and feet via a Results Unit selector, independent of the input unit.

## Files Changed

| File | Change |
|---|---|
| `html/calculators/height_loss_calculator.html` | New calculator page |
| `html/js/height_loss_calculator.js` | New calculator logic |
| `html/Main.html` | New sidebar entry under **ILS** |
| `html/js/main_app.js` | `PAGE_MAP`/`PAGE_TITLES` entries |
| `html/i18n/en.json`, `html/i18n/es.json` | New `heightLoss` namespace; added `common.yes`/`common.no` |

## Testing

Verified locally (headless Edge via Playwright) against a local static server, using the exact spreadsheet sample (AD elevation 1200 m, VPA 3.5°):

- [x] Both Yes/No indicators show "Yes".
- [x] All 4 category rows match the workbook's cached values exactly.
- [x] Results Unit selector correctly converts all 5 numeric columns between m/ft.
- [x] Entering elevation in feet produces identical results to the equivalent value in meters.
- [x] Copy-to-Word guard clause, clipboard content (summary + category table), Save/Load round-trip, sidebar navigation under ILS, topbar title, and i18n (en/es) all verified.
- [x] No new console errors.

## Not changed / out of scope

- Vat values per aircraft category are fixed (matching the workbook exactly), not user-editable — confirmed with the user this is standard reference data, not a per-calculation input.
